### PR TITLE
석원담 정보가 _people2_.txt에 추가

### DIFF
--- a/_people2_.txt
+++ b/_people2_.txt
@@ -1,25 +1,20 @@
 권민석 lpoipk
 
-
-
 한상익 hansangik
-
 
 오형환 ohhyeonghwan
 
 이재혁 Jae-Hyuk-Lee
+
 조상준 joon0447
+
 정문경 moongyeong000
 
 최현민 cmin03
 
-
 이슬찬 lsc1124
 
-
 한성준 StaySober01
-
-
 
 안현준 AnhyunJun1741
 
@@ -29,27 +24,14 @@
 
 손정헌 Bluewak
 
-
-
-
-
 이재웅 dbrhr5
-
-
-
-
-
-
-
 
 이도빈 eunoa
 
 오재원 jaewon786
 
-
-
-
 윤여명 Sernn0
 
 김우진 lad-blip
 
+석원담 seokwd


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/249
위의 이슈를 해결하기위해
석원담 정보가 _people2_.txt에 추가