### PR TITLE
[FIX] --output 옵션이 출력 디렉토리에 제대로 반영되지 않던 문제 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ pip install -r requirements.txt
 명령줄 관련 코드가 변경되면 아래 내용도 그에 맞게 수정해야 함.
 
 ```
-usage: python -m reposcore [-h] --repo owner/repo [--output filename] [--format {table,chart,both}]
+usage: python -m reposcore [-h] --repo owner/repo [--output dir_name] [--format {table,chart,both}]
 
 오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구
 
 options:
   -h, --help            도움말 표시 후 종료
   --repo owner/repo     분석할 GitHub 저장소 (형식: '소유자/저장소')
-  --output filename     분석 결과를 저장할 출력 디렉토리 (기본값: 'results')
+  --output dir_name     분석 결과를 저장할 디렉토리 (기본값: 'results')
   --format {table,chart,both}
                         결과 출력 형식 선택 (테이블: 'table', 차트: 'chart', 둘 다: 'both')
 ```

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+import os
 import requests
 from .analyzer import RepoAnalyzer
 
@@ -86,16 +87,18 @@ def main():
         # Calculate scores
         scores = analyzer.calculate_scores()
         
+        output_dir = args.output
+        os.makedirs(output_dir, exist_ok=True)
         # Generate outputs based on format
         if args.format in ["table", "both"]:
-            table = analyzer.generate_table(scores)
-            table.to_csv(f"{args.output}_scores.csv")
-            print("\nParticipation Scores Table:")
-            print(table)
+            table_path = os.path.join(output_dir, "table.csv")
+            analyzer.generate_table(scores, save_path=table_path)
+            print(f"\nThe table has been saved as 'table.csv' in the '{output_dir}' directory.")
             
         if args.format in ["chart", "both"]:
-            analyzer.generate_chart(scores)
-            print(f"Chart saved as participation_chart.png")
+            chart_path = os.path.join(output_dir, "chart.png")
+            analyzer.generate_chart(scores, save_path=chart_path)
+            print(f"\nThe chart has been saved as 'chart.png' in the '{output_dir}' directory.")
             
     except Exception as e:
         print(f"Error: {str(e)}", file=sys.stderr)

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -62,12 +62,12 @@ class RepoAnalyzer:
         return scores
 
 
-    def generate_table(self, scores: Dict) -> pd.DataFrame:
+    def generate_table(self, scores: Dict, save_path: str = "results") -> None:
         """Generate a table of participation scores"""
         df = pd.DataFrame.from_dict(scores, orient='index', columns=['Score'])
-        return df
+        df.to_csv(save_path)
 
-    def generate_chart(self, scores: Dict) -> None:
+    def generate_chart(self, scores: Dict, save_path: str = "results") -> None:
         """Generate a visualization of participation scores"""
         plt.figure(figsize=(10, 6))
         plt.bar(scores.keys(), scores.values())
@@ -75,4 +75,4 @@ class RepoAnalyzer:
         plt.ylabel('Participation Score')
         plt.title('Repository Participation Scores')
         plt.tight_layout()
-        plt.savefig('participation_chart.png')
+        plt.savefig(save_path)


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/275 --output 옵션의 동작이 실제와 다름 이슈에 대한 PR입니다.

** Version (commit id) **
ea6255f843c8615af12cfc05909d3cc87cb257d5

--output 옵션으로 명시된 리렉토리 하위에 table.csv, chart.png 파일이 생성 되도록 수정했습니다.
--output 옵션 미지정시 기본값인 results 디렉토리 하위에 생성됩니다.
