### PR TITLE
[REFACTOR] generate_table 함수 수정.

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -89,9 +89,9 @@ def main():
         os.makedirs(output_dir, exist_ok=True)
         # Generate outputs based on format
         if args.format in ["table", "both"]:
-            table_path = os.path.join(output_dir, "table.csv")
+            table_path = os.path.join(output_dir, "table.txt")
             analyzer.generate_table(scores, save_path=table_path)
-            print(f"\nThe table has been saved as 'table.csv' in the '{output_dir}' directory.")
+            print(f"\nThe table has been saved as 'table.txt' in the '{output_dir}' directory.")
             
         if args.format in ["chart", "both"]:
             chart_path = os.path.join(output_dir, "chart.png")

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -7,7 +7,7 @@ import pandas as pd
 import requests
 from prettytable import PrettyTable
 
-scores_temp = {}
+scores_temp = {} # 임시 전역변수. 추후 scores와 통합 예정.
 
 class RepoAnalyzer:
     """Class to analyze repository participation for scoring"""


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/290 해당 이슈의 generate_table 함수 수정 요청에 대한 PR입니다.

**Specify version (commit id).**
589b1fb62d358dfc63069913cb8f9dadddb92f6f

**수정사항**
기존 `table.csv` 파일을 생성하던 generate_table 함수를 PrettyTable을 이용한 테이블이 출력되는 txt 파일을 생성하도록 변경하였습니다.

총 점수를 기준으로 내림차순으로 정렬하였고, 각 열은 
"name", "feat/bug PR","document PR","feat/bug issue","document issue","total" 으로 구성되어있습니다.  한글로 작성시 테이블이 깨지는 경우가 있어 영어로 작성하였습니다.

이때 각각의 점수가 필요한데 `scores`에는  총 점수만 기록되어있어 이에 알맞게 `scores` 를 변경하려 했으나, 
`scores` 값을 사용하는 generate_chart 함수에 대한 구현이 현재 이루어지고 있어 임시적으로 `scores_temp = {}` 전역변수를 선언후 각각의 값을 담아주었습니다. 

추후 generate_chart 함수구현 PR과 해당 PR이 모두 병합된 후 다시 하나의 `scores` 변수로 합치는 이슈를 생성해야 할 듯 합니다.