### PR TITLE
#297 [FEAT] README의 Usage 자동 동기화(--help 출력 결과 반영)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,12 @@ make requirements
 ```
 
 ## Usage
-아래는 `python -m reposcore -h` 또는 `python -m reposcore --help` 실행 결과를 붙여넣은 것이므로
-명령줄 관련 코드가 변경되면 아래 내용도 그에 맞게 수정해야 함.
+> **주의**: 이 섹션은 자동 동기화됩니다. 직접 수정하지 마세요.
 
-```
-usage: python -m reposcore [-h] --repo owner/repo [--output dir_name] [--format {table,chart,both}]
+```bash
+'{{ help_output }}'
 
-오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구
 
-options:
-  -h, --help            도움말 표시 후 종료
-  --repo owner/repo     분석할 GitHub 저장소 (형식: '소유자/저장소')
-  --output dir_name     분석 결과를 저장할 디렉토리 (기본값: 'results')
-  --format {table,chart,both}
-                        결과 출력 형식 선택 (테이블: 'table', 차트: 'chart', 둘 다: 'both')
 ```
 
 ## Test

--- a/reposcore/__init__.py
+++ b/reposcore/__init__.py
@@ -1,2 +1,21 @@
 # Empty or with basic package info
 __version__ = "0.1.0"
+import subprocess, re
+from jinja2 import Environment, FileSystemLoader
+
+def update_readme_section():
+    # 1) help 출력
+    help_out = subprocess.check_output(
+        ["python", "-m", "reposcore", "--help"], text=True
+    )
+    # 2) 템플릿 렌더링
+    env = Environment(loader=FileSystemLoader("."))  # 루트에서 docs 폴더를 찾도록
+    tpl = env.get_template("docs/usage.j2")
+    rendered = tpl.render(help_output=help_out)
+    # 3) README.md 교체
+    with open("README.md", "r", encoding="utf-8") as f:
+        content = f.read()
+    new = re.sub(r"## Usage[\\s\\S]*?(?=## )", rendered, content)
+    with open("README.md", "w", encoding="utf-8") as f:
+        f.write(new)
+    print("✅ README Usage 동기화 완료")

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -55,7 +55,8 @@ def parse_arguments() -> argparse.Namespace:
 def main():
     # --sync-readme 플래그가 있으면 argparse 없이 처리
     if "--sync-readme" in sys.argv:
-        from .update_readme import update_readme_section
+    # 루트에 있는 update_readme.py 사용
+        from update_readme import update_readme_section
         update_readme_section()
         sys.exit(0)
 

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -53,12 +53,6 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 def main():
-    # --sync-readme 플래그가 있으면 argparse 없이 처리
-    if "--sync-readme" in sys.argv:
-    # 루트에 있는 update_readme.py 사용
-        from update_readme import update_readme_section
-        update_readme_section()
-        sys.exit(0)
 
     args = parse_arguments()
 

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -6,29 +6,24 @@ import os
 import requests
 from .analyzer import RepoAnalyzer
 
-# 깃허브 저장소 기본 URL
 GITHUB_BASE_URL = "https://github.com/"
 
 def validate_repo_format(repo: str) -> bool:
-    """Check if the repo input follows 'owner/repo' format"""
-    parts = repo.split("/") # '/'를 기준으로 분리 (예: 'oss2025hnu/reposcore-py' → ['oss2025hnu', 'reposcore-py'])
-    return len(parts) == 2 and all(parts) # 두 개의 부분(owner, repo)이 존재해야 하고, 비어 있으면 안 됨
+    parts = repo.split("/")
+    return len(parts) == 2 and all(parts)
 
 def check_github_repo_exists(repo: str) -> bool:
-    """Check if the given GitHub repository exists"""
-    url = f"https://api.github.com/repos/{repo}" # 예: 'oss2025hnu/reposcore-py' → 'https://api.github.com/repos/oss2025hnu/reposcore-py'
-    response = requests.get(url) # API 요청 보내기
-    return response.status_code == 200 # 응답코드가 정상이면 저장소가 존재함
+    url = f"https://api.github.com/repos/{repo}"
+    response = requests.get(url)
+    return response.status_code == 200
 
 def parse_arguments() -> argparse.Namespace:
-    """커맨드라인 인자를 파싱하는 함수"""
     parser = argparse.ArgumentParser(
         prog="python -m reposcore",
         usage="python -m reposcore [-h] --repo owner/repo [--output dir_name] [--format {table,chart,both}]",
         description="오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구",
-        add_help=False  # 기본 --help 옵션을 비활성화
+        add_help=False
     )
-    
     parser.add_argument(
         "-h", "--help",
         action="help",
@@ -57,47 +52,44 @@ def parse_arguments() -> argparse.Namespace:
     )
     return parser.parse_args()
 
-
 def main():
-    """Main execution function"""
+    # --sync-readme 플래그가 있으면 argparse 없이 처리
+    if "--sync-readme" in sys.argv:
+        from .update_readme import update_readme_section
+        update_readme_section()
+        sys.exit(0)
+
     args = parse_arguments()
 
-    # Validate repo format
     if not validate_repo_format(args.repo):
-        print("오류 : --repo 옵션은 'owner/repo' 형식으로 입력해야 함. 예) 'oss2025hnu/reposcore-py'")
+        print("오류 : --repo 옵션은 'owner/repo' 형식으로 입력해야 함.")
         sys.exit(1)
 
-    # (Optional) Check if the repository exists on GitHub
     if not check_github_repo_exists(args.repo):
         print(f"입력한 저장소 '{args.repo}' 가 깃허브에 존재하지 않을 수 있음.")
-    
+
     print(f"저장소 분석 시작 : {args.repo}")
-
-    # Initialize analyzer
     analyzer = RepoAnalyzer(args.repo)
-    
+
     try:
-        # Collect participation data
-
         print("Collecting PRs_and_issues data...")
-        analyzer.collect_PRs_and_issues()    
+        analyzer.collect_PRs_and_issues()
 
-        # Calculate scores
         scores = analyzer.calculate_scores()
-        
+
         output_dir = args.output
         os.makedirs(output_dir, exist_ok=True)
-        # Generate outputs based on format
+
         if args.format in ["table", "both"]:
             table_path = os.path.join(output_dir, "table.csv")
             analyzer.generate_table(scores, save_path=table_path)
-            print(f"\nThe table has been saved as 'table.csv' in the '{output_dir}' directory.")
-            
+            print(f"\nThe table has been saved as 'table.csv' in '{output_dir}'.")
+
         if args.format in ["chart", "both"]:
             chart_path = os.path.join(output_dir, "chart.png")
             analyzer.generate_chart(scores, save_path=chart_path)
-            print(f"\nThe chart has been saved as 'chart.png' in the '{output_dir}' directory.")
-            
+            print(f"\nThe chart has been saved as 'chart.png' in '{output_dir}'.")
+
     except Exception as e:
         print(f"Error: {str(e)}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/297 #297 [FEAT] README의 Usage 자동 동기화(--help 출력 결과 반영)에 대한 PR입니다.

Specify version (commit id) 

b11bda44b76be0347c9fe53799416817373093b5

변경사항
Usage 섹션을 하드코딩된 예시에서 템플릿 플레이스홀더로 교체

버전 정보 아래에 자동 동기화 함수를 추가


Describe alternatives you've considered
현재는 README.md의 Usage 섹션을 코드 변경 후 수동으로 수정하고 있습니다.
CI 단계에서 간단한 sed 스크립트를 사용해 --help 출력과 일치시키는 방법도 고려했습니다.
