### PR TITLE
캐시 기능 추가 및 결과 파일 무시 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# 분석 결과 및 캐시 파일 무시
+*.csv
+*.png
+cache.json
+


### PR DESCRIPTION
#306  GitHub 데이터 수집 결과 캐시 기능 추가

**Version (commit id)**  
8e24367bc5b6a767816cddc10ff827f7f2a2cd15

**수정 사항**  
- `--use-cache` 옵션을 통해 participants 데이터를 캐시(`cache.json`)로 저장/불러오는 기능을 추가했습니다.
- 캐시가 존재하고 `--use-cache` 옵션이 주어졌을 경우, GitHub API 호출 없이 캐시 파일을 불러옵니다.
- 캐시 파일이 없거나 `--use-cache`가 없는 경우, 기존 방식대로 데이터를 수집하고 캐시에 저장합니다.
- 결과 파일(`table.csv`, `chart.png`)은 `.gitignore`에 의해 커밋되지 않도록 설정했습니다.

**Describe alternatives you've considered**  
- 매 실행 시마다 새롭게 데이터를 불러오는 방식은 비효율적이라 자동 캐시 방식으로 구현했습니다.
- 수동 지정 방식도 고려했지만, 현재는 자동 캐시가 더 직관적입니다.

**추가 설명**  
- 캐시 파일 이름은 `cache.json`이며, 저장 디렉토리는 `--output` 인자에 따라 결정됩니다.