### PR TITLE
--repo 옵션에 대한 에지 케이스 처리 추가

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,3 +22,32 @@ def test_main_repo_runs():
     # 비정상적인 종료 (예: AttributeError) 가 없어야 함
     assert result.returncode == 0
     assert "저장소 분석 시작" in result.stdout or "Participation Scores Table" in result.stdout
+
+def test_main_without_repo_option():
+    """--repo 옵션 없이 실행했을 때 에러 출력 확인"""
+    result = subprocess.run(
+        [sys.executable, "-m", "reposcore"],
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode != 0
+    assert "repo 옵션은 'owner/repo' 형식으로 입력해야 함" in result.stdout or "required" in result.stderr
+
+def test_main_invalid_repo_format():
+    """잘못된 형식의 --repo 인자에 대한 처리"""
+    result = subprocess.run(
+        [sys.executable, "-m", "reposcore", "--repo", "invalid_repo_format"],
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode != 0
+    assert "repo 옵션은 'owner/repo' 형식으로 입력해야 함" in result.stdout
+
+def test_main_nonexistent_repo():
+    """존재하지 않는 저장소 입력시 경고 메시지 확인"""
+    result = subprocess.run(
+        [sys.executable, "-m", "reposcore", "--repo", "this/doesnotexist123"],
+        capture_output=True,
+        text=True
+    )
+    assert "가 깃허브에 존재하지 않을 수 있음" in result.stdout


### PR DESCRIPTION
#317 [FEAT] --repo 옵션에 대한 에지 케이스 처리 추가에 대한 PR입니다.
Specify version (commit id).
13b54253d70ca7c66a9caddf3ef03fc62bfe9daa

추가사항
`reposcore/__main__.py`의 `--repo` 옵션과 관련된 예외 상황에 대한 테스트를
 `tests/test_main.py`에 추가했습니다.
다음과 같은 에지 케이스에 대해 테스트를 작성
  - `--repo` 옵션 없이 실행한 경우  
  - 잘못된 형식의 저장소를 입력한 경우  
  - 존재하지 않는 GitHub 저장소를 입력한 경우

Test Result
`make test` 명령어를 통해 모든 테스트가 정상적으로 통과했음을 확인했습니다.