### PR TITLE
[FEAT] generate_table 수정 및 generate_text 생성

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ usage: python -m reposcore [-h] --repo owner/repo [--output dir_name] [--format 
 options:
   -h, --help            도움말 표시 후 종료
   --repo owner/repo     분석할 GitHub 저장소 (형식: '소유자/저장소')
-  --output dir_name     분석 결과를 저장할 디렉토리 (기본값: 'results')
-  --format {table,chart,both}
-                        결과 출력 형식 선택 (테이블: 'table', 차트: 'chart', 둘 다: 'both')
+  --output dir_name     분석 결과를 저장할 출력 디렉토리 (기본값: 'results')
+  --format {table,text,chart,both}
+                        결과 출력 형식 선택 (테이블: 'table', 텍스트 : 'text', 차트: 'chart', 모두 : 'all')
+  --use-cache           participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)
 ```
 
 ## Test

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -50,10 +50,10 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--format",
-        choices=["table", "chart", "both"],
-        default="both",
-        metavar="{table,chart,both}",
-        help="결과 출력 형식 선택 (테이블: 'table', 차트: 'chart', 둘 다: 'both')"
+        choices=["table", "text", "chart", "all"],
+        default="all",
+        metavar="{table,text,chart,both}",
+        help = "결과 출력 형식 선택 (테이블: 'table', 텍스트 : 'text', 차트: 'chart', 모두 : 'all')"
     )
 
     parser.add_argument(
@@ -108,16 +108,21 @@ def main():
         scores = analyzer.calculate_scores()
         
         # Generate outputs based on format
-        if args.format in ["table", "both"]:
+        if args.format in ["table", "text", "all"]:
             table_path = os.path.join(output_dir, "table.csv")
             analyzer.generate_table(scores, save_path=table_path)
             print(f"\nThe table has been saved as 'table.csv' in the '{output_dir}' directory.")
-            
-        if args.format in ["chart", "both"]:
+
+        if args.format in ["text", "all"]:
+            txt_path = os.path.join(output_dir, "table.txt")
+            analyzer.generate_text(txt_path)
+            print(f"\nThe table has been saved as 'table.txt' in the '{output_dir}' directory.")
+
+        if args.format in ["chart", "all"]:
             chart_path = os.path.join(output_dir, "chart.png")
             analyzer.generate_chart(scores, save_path=chart_path)
             print(f"\nThe chart has been saved as 'chart.png' in the '{output_dir}' directory.")
-            
+                     
     except Exception as e:
         print(f"Error: {str(e)}", file=sys.stderr)
         sys.exit(1)

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -4,7 +4,9 @@ from typing import Dict
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
+from prettytable import PrettyTable
 
+scores_temp = {} # 임시 전역변수. 추후 scores와 통합 예정.
 
 class RepoAnalyzer:
     """Class to analyze repository participation for scoring"""
@@ -84,15 +86,6 @@ class RepoAnalyzer:
         page = 1
         pages_remaining = True
 
-        while pages_remaining:
-            # GitHub Issues API (pull request 역시 issue로 취급)
-            url = f'https://api.github.com/repos/{self.repo_path}/issues'
-            response = requests.get(url,
-                                    params={
-                                        'state': 'all',
-                                        'per_page': per_page,
-                                        'page': page
-                                    })
 
         print("\n참여자별 활동 내역 (participants 딕셔너리):")
         for user, info in self.participants.items():
@@ -101,6 +94,7 @@ class RepoAnalyzer:
     def calculate_scores(self) -> Dict:
         """Calculate participation scores for each contributor using the refactored formula"""
         scores = {}
+        global scores_temp
         for participant, activities in self.participants.items():
             p_f = activities.get('p_enhancement', 0)
             p_b = activities.get('p_bug', 0)
@@ -123,13 +117,45 @@ class RepoAnalyzer:
 
             S = 3 * p_fb_at + 2 * p_d_at + 2 * i_fb_at + 1 * i_d_at
             scores[participant] = S
+            # 임시 코드
+            scores_temp[participant] = {
+                "feat/bug PR": 3 * p_fb_at,
+                "document PR": 2 * p_d_at,
+                "feat/bug issue": 2 * i_fb_at,    
+                "document issue": 1 * i_d_at,
+                "total" : S
+            }
+            # 임시 코드
+            
+        # 내림차순 정렬
+        scores_temp = dict(sorted(scores_temp.items(), key=lambda x: x[1]["total"], reverse=True))
 
         return scores
 
-    def generate_table(self, scores: Dict, save_path: str = "results") -> None:
+    def generate_table(self, scores: Dict, save_path) -> None:
         """Generate a table of participation scores"""
-        df = pd.DataFrame.from_dict(scores, orient='index', columns=['Score'])
+        global scores_temp
+        df = pd.DataFrame.from_dict(scores_temp, orient="index")
         df.to_csv(save_path)
+
+    def generate_text(self, save_path) -> None:
+        """Generate a table of participation scores"""
+        global scores_temp
+        table = PrettyTable()
+        table.field_names = ["name", "feat/bug PR","document PR","feat/bug issue","document issue","total"]
+        for name, score in scores_temp.items():
+            table.add_row(
+                [name, 
+                score["feat/bug PR"], 
+                score["document PR"], 
+                score['feat/bug issue'], 
+                score['document issue'], 
+                score['total']]
+            )
+
+        # table.txt 작성
+        with open(save_path, 'w') as txt_file:
+            txt_file.write(str(table))
 
     def generate_chart(self, scores: Dict, save_path: str = "results") -> None:
         """Generate a visualization of participation scores"""


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/290 해당 이슈에 대한 PR입니다.

Specify version (commit id).
e19389858589bd03ae04888d11b1529c5418a083

**수정사항**
기존 csv 파일을 생성하던`generate_table`함수를 유지한채, 기존에는 총점만 기록하였지만 현재는 각각의 점수와 총점을 기록하도록 변경하였습니다.
PrettyTable을 사용한 테이블을 출력하는 `generate_text` 함수를 구현하였습니다.
명령줄 인자의 --format이 'table', 'text', 'chart', 'all' 로 변경되었으며, 'table' 선택시 csv파일만을, 'text' 선택시 'csv' 파일과 'txt'파일을 생성합니다. 'all' 선택시 모든 파일을 생성합니다.

generate_table 함수와 generate_text가 각각의 점수를 기록하는 과정에서, 기존의 `scores`는 총점만을 가지고 있기 떄문에 변경이 필요하였습니다. 하지만 현재 generate_chart 에서 기존의 `scores`를 사용중이기 때문에 임시로 `scores_temp` 전역변수를 선언하였고, 각 부분의 점수와 총점을 담아 사용하였습니다.

이 부분은 추후 `scores` 가 `scores_temp` 의 값을 가지게 변경하고, 변경된  `scores` 에 알맞게 `generate_table` , `generate_text `  , `generate_chart` 를 수정하는 이슈를 생성하는게 좋을 것 같습니다.