### PR TITLE
GitHub API 요청 시 비로그인 유저 rate limit 초과 문제 개선 PR

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -61,6 +61,12 @@ def parse_arguments() -> argparse.Namespace:
         help="participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)"
     )
 
+    parser.add.argument(
+        '--token',
+        type=str,
+        help='API 요청 제한 해제를 위한 깃허브 개인 액세스 토큰'
+    )
+
     return parser.parse_args()
 
 
@@ -83,7 +89,7 @@ def main():
 
     # Initialize analyzer
 
-    analyzer = RepoAnalyzer(args.repository)
+    analyzer = RepoAnalyzer(args.repository, token=args.token)
     
         # 디렉토리 먼저 생성
     output_dir = args.output

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Dict
+from typing import Dict, Optional
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
@@ -12,8 +12,9 @@ scores_temp = {} # 임시 전역변수. 추후 scores와 통합 예정.
 class RepoAnalyzer:
     """Class to analyze repository participation for scoring"""
 
-    def __init__(self, repo_path: str):
+    def __init__(self, repo_path: str, token: Optional[str] = None):
         self.repo_path = repo_path
+        self.token = token
         self.participants: Dict = {}
         self.score_weights = {
             'PRs': 1,  # 이 부분은 merge된 PR의 PR 갯수, issues 갯수만 세기 위해 임시로 1로 변경


### PR DESCRIPTION
[FEAT] GitHub API 요청 시 비로그인 유저 rate limit 초과 문제 개선https://github.com/oss2025hnu/reposcore-py/issues/301 에 대한 PR입니다.

**Specify version (commit id)**
623ce447f12da6b4b409d11567d2da0fb7788ca9

**변경사항**
GitHub API 요청 시 인증을 통해 rate limit 문제를 해소할 수 있도록 하기 위해, CLI에서 GitHub Personal Access Token을 입력받을 수 있는 기능을 추가했습니다. 해당 토큰은 RepoAnalyzer에 전달되어 이후 API 요청 시 인증 헤더에 활용될 수 있도록 구조를 준비했습니다.
- -token CLI 인자 추가
- RepoAnalyzer 클래스에 -token 인자 및 필드 추가
- 향후 Github API 호출 시 인증 헤더에 사용할 준비를 마쳤습니다. (헤더 추가 및 구현까지는 제 능력 밖의 일이었습니다..)
