### PR TITLE
[FEAT] Makefile에 clean 타겟 추가

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
 
       - name: 의존성 설치
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: Python CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 리포지토리 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Python 환경 설정
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      -name: 의존성 설치
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: pytest를 사용한 테스트 실행
+        run: |
+          pytest tests --verbose --junitxml=test-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload=artifact@v4
+        with:
+          name: test-results
+          path: test-results.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
 
-      -name: 의존성 설치
+      - name: 의존성 설치
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
@@ -28,9 +29,10 @@ jobs:
         run: |
           pytest tests --verbose --junitxml=test-results.xml
 
+      # Push, Pull request시 테스트를 시행하고 결과를 test-results.xml로 생성함
       - name: Upload test results
         if: always()
-        uses: actions/upload=artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results.xml

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,14 @@ readme:
 
 # PR 전에 자동으로 README 검증
 pre-commit: readme
+
+# 불필요한 파일 정리
+clean:
+	@if [ -d "$(VENV)" ]; then \
+		echo ".venv 가상 환경을 삭제합니다..."; \
+		rm -rf $(VENV); \
+	fi
+	@if [ -d "results" ]; then \
+		echo "results 디렉토리를 삭제합니다..."; \
+		rm -rf results; \
+	fi


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/329
커밋 이전에 make clean 을 실행하여 커밋에 불필요한 파일들을 제거한 후 깨끗하게 커밋을 유도할 수 있는 makefile에 clean 기능 요청에 대한 PR입니다. 

변경 내용 : 
makefile에 'clean' 타겟 추가
.venv, results 디렉토리가 존재할 경우 삭제
삭제 시 안내 메시지 출력

테스트 결과

@kjason0102 ➜ /workspaces/reposcore-py-kjs (clean) $ make clean
@kjason0102 ➜ /workspaces/reposcore-py-kjs (clean) $ python3 -m venv .venv
@kjason0102 ➜ /workspaces/reposcore-py-kjs (clean) $ mkdir results
@kjason0102 ➜ /workspaces/reposcore-py-kjs (clean) $ touch results/test_output.txt
@kjason0102 ➜ /workspaces/reposcore-py-kjs (clean) $ make clean
.venv 가상 환경을 삭제합니다...
results 디렉토리를 삭제합니다...


#브랜치 관련 : 기존 PR브랜치에서 해당 이슈를 해결하려 했으나 PR이 보류된 상태에서 같은 브랜치로 추가 커밋을 올릴 수 없었습니다. 따라서 별도의 브랜치 "clean"을 생성하여 PR을 새로 제출하였습니다.
#교수님의 코멘트를 참고하여 result 디렉토리는 삭제해도 무방하다는 판단에 따라 포함했습니다. 삭제 시 디렉토리 존재 여부를 확인하므로 실수로 다른 파일이 삭제되는 문제는 발생하지 않습니다. 
