### PR TITLE
[DOC] Tests suite 사용 방법을 README.md에서 분리하여 구체화

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,64 +37,7 @@ options:
 ```
 
 ## Test
-
-이 저장소에서 기본적인 동작 이상 여부를 테스트하기 위한 자동화된 테스트 스위트를 사용할 수 있습니다.
-
-### Install dependencies
-
-테스트 과정을 진행하기 위해서 먼저 설치 후 실행.
-```bash
-make venv
-make requirements
-```
-
-### Run Tests
-다음 명령어를 수행하면 테스트가 진행됩니다.
-```bash
-make test
-```
-
-### How to Read Test Results
-
-테스트 실행 결과는 다음과 같은 형식으로 출력됩니다.
-```
-=== test session starts ===
-...
-collected 3 items
-
-tests/test_analyzer.py ..F [100%]
-
-=== FAILURES ===
-tests/test_analyzer.py::test_analyzer_initialization
-```
-- `.` : 테스트 성공
-- `F` : 테스트 실패
-- `[100%]` : 전체 테스트 실행 비율
-
-자세한 실패 원인은 터미널 로그에서 확인할 수 있습니다.
-
-### Writing New Tests
-
-새로운 기능을 추가하면 `tests/` 디렉터리에 테스트 파일을 작성해야 합니다.
-
-#### 예시 테스트 파일 (`tests/test_analyzer.py`)
-```python
-import pytest
-from reposcore.analyzer import RepoAnalyzer
-
-@pytest.fixture
-def analyzer():
-    return RepoAnalyzer("oss2025hnu/reposcore-py")
-
-def test_initialization(analyzer):
-    assert analyzer.repo == "oss2025hnu/reposcore-py"
-    assert isinstance(analyzer.scores, dict)
-
-def test_add_score(analyzer):
-    analyzer.add_score("jass2345", 10)
-    assert analyzer.scores["jass2345"] == 10
-```
-원하는 테스트를 추가한 후 `make test`를 실행하여 검증하세요.
+👉 [테스트 가이드 보기](docs/test-guide.md)
 
 ## Score Formula
 아래는 PR 개수와 이슈 개수의 비율에 따라 점수로 인정가능한 최대 개수를 구하고 각 배점에 따라 최종 점수를 산출하는 공식이다.

--- a/docs/test-guide.md
+++ b/docs/test-guide.md
@@ -1,0 +1,59 @@
+# Test
+
+이 저장소에서 기본적인 동작 이상 여부를 테스트하기 위한 자동화된 테스트 스위트를 사용할 수 있습니다.
+
+### Install dependencies
+
+테스트 과정을 진행하기 위해서 먼저 설치 후 실행.
+```bash
+make venv
+make requirements
+```
+
+### Run Tests
+다음 명령어를 수행하면 테스트가 진행됩니다.
+```bash
+make test
+```
+
+### How to Read Test Results
+
+테스트 실행 결과는 다음과 같은 형식으로 출력됩니다.
+```
+=== test session starts ===
+...
+collected 3 items
+
+tests/test_analyzer.py ..F [100%]
+
+=== FAILURES ===
+tests/test_analyzer.py::test_analyzer_initialization
+```
+- `.` : 테스트 성공
+- `F` : 테스트 실패
+- `[100%]` : 전체 테스트 실행 비율
+
+자세한 실패 원인은 터미널 로그에서 확인할 수 있습니다.
+
+### Writing New Tests
+
+새로운 기능을 추가하면 `tests/` 디렉터리에 테스트 파일을 작성해야 합니다.
+
+#### 예시 테스트 파일 (`tests/test_analyzer.py`)
+```python
+import pytest
+from reposcore.analyzer import RepoAnalyzer
+
+@pytest.fixture
+def analyzer():
+    return RepoAnalyzer("oss2025hnu/reposcore-py")
+
+def test_initialization(analyzer):
+    assert analyzer.repo == "oss2025hnu/reposcore-py"
+    assert isinstance(analyzer.scores, dict)
+
+def test_add_score(analyzer):
+    analyzer.add_score("jass2345", 10)
+    assert analyzer.scores["jass2345"] == 10
+```
+원하는 테스트를 추가한 후 `make test`를 실행하여 검증하세요.

--- a/template_README.md
+++ b/template_README.md
@@ -23,64 +23,7 @@ make requirements
 ```
 
 ## Test
-
-이 저장소에서 기본적인 동작 이상 여부를 테스트하기 위한 자동화된 테스트 스위트를 사용할 수 있습니다.
-
-### Install dependencies
-
-테스트 과정을 진행하기 위해서 먼저 설치 후 실행.
-```bash
-make venv
-make requirements
-```
-
-### Run Tests
-다음 명령어를 수행하면 테스트가 진행됩니다.
-```bash
-make test
-```
-
-### How to Read Test Results
-
-테스트 실행 결과는 다음과 같은 형식으로 출력됩니다.
-```
-=== test session starts ===
-...
-collected 3 items
-
-tests/test_analyzer.py ..F [100%]
-
-=== FAILURES ===
-tests/test_analyzer.py::test_analyzer_initialization
-```
-- `.` : 테스트 성공
-- `F` : 테스트 실패
-- `[100%]` : 전체 테스트 실행 비율
-
-자세한 실패 원인은 터미널 로그에서 확인할 수 있습니다.
-
-### Writing New Tests
-
-새로운 기능을 추가하면 `tests/` 디렉터리에 테스트 파일을 작성해야 합니다.
-
-#### 예시 테스트 파일 (`tests/test_analyzer.py`)
-```python
-import pytest
-from reposcore.analyzer import RepoAnalyzer
-
-@pytest.fixture
-def analyzer():
-    return RepoAnalyzer("oss2025hnu/reposcore-py")
-
-def test_initialization(analyzer):
-    assert analyzer.repo == "oss2025hnu/reposcore-py"
-    assert isinstance(analyzer.scores, dict)
-
-def test_add_score(analyzer):
-    analyzer.add_score("jass2345", 10)
-    assert analyzer.scores["jass2345"] == 10
-```
-원하는 테스트를 추가한 후 `make test`를 실행하여 검증하세요.
+👉 [테스트 가이드 보기](docs/test-guide.md)
 
 ## Score Formula
 아래는 PR 개수와 이슈 개수의 비율에 따라 점수로 인정가능한 최대 개수를 구하고 각 배점에 따라 최종 점수를 산출하는 공식이다.


### PR DESCRIPTION
[DOC] Tests suite 사용 방법을 README.md에서 분리하여 구체화에 대한 PR입니다 https://github.com/oss2025hnu/reposcore-py/issues/304

Specify version (commit id) https://github.com/oss2025hnu/reposcore-py/commit/281e676b43fbd8de2b3825de2d5dd17c1fa81159

**변경사항**
- `README.md` 및 `template_README.md`에서 테스트 실행 관련 파트 내용 제거
- 새로운 문서 `docs/test-guide.md` 생성
- `README.md` 내 `test-guid.md`로 통하는 링크 추가

**Describe alternatives you've considered**
- `README.md`에 적힌대로 `make readme`를 통해 변경 완료.
- 테스트의 설명을 `README`에 적는 것에서 문서 구조의 명확성과 유지보수를 위해 별도 문서 생성 후 관리로 결정함.