### PR TITLE
Add feature to retrieve token from env variable or stdin

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -73,6 +73,12 @@ def parse_arguments() -> argparse.Namespace:
 def main():
     """Main execution function"""
     args = parse_arguments()
+    github_token = args.token
+
+    if not args.token:
+        github_token = os.getenv('GITHUB_TOKEN')
+    elif args.token == '-':
+        github_token = sys.stdin.readline().strip()
 
     # Validate repo format
 
@@ -89,7 +95,7 @@ def main():
 
     # Initialize analyzer
 
-    analyzer = RepoAnalyzer(args.repository, token=args.token)
+    analyzer = RepoAnalyzer(args.repository, token=github_token)
     
         # 디렉토리 먼저 생성
     output_dir = args.output


### PR DESCRIPTION
[#346](https://github.com/oss2025hnu/reposcore-py/issues/346)

GitHub token을 환경변수 혹은 표준 입력(stdin)을 통해 설정할 수 있도록 수정했습니다.

```--token``` 옵션이 없거나 비어 있으면 ```GITHUB_TOKEN``` 환경 변수에서 불러오고, 만약 ```-``` 라면 표준 입력에서 불러옵니다.