### PR TITLE
[FEAT] GitHub API 요청 시 비로그인 유저 rate limit 초과 문제 개선

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -75,7 +75,6 @@ def main():
     args = parse_arguments()
 
     # Validate repo format
-
     if not validate_repo_format(args.repository):
         print("오류 : 저장소는 'owner/repo' 형식으로 입력해야 함. 예) 'oss2025hnu/reposcore-py'")
         sys.exit(1)

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
+import requests
 from prettytable import PrettyTable
 
 from .utils.retry_request import retry_request
@@ -13,13 +14,14 @@ class RepoAnalyzer:
 
     def __init__(self, repo_path: str, token: Optional[str] = None):
         self.repo_path = repo_path
-        self.token = token
         self.participants: Dict = {}
         self.score_weights = {
             'PRs': 1,  # 이 부분은 merge된 PR의 PR 갯수, issues 갯수만 세기 위해 임시로 1로 변경
             'issues_created': 1,  # 향후 배점이 필요할 경우 PRs: 0.4, issues: 0.3으로 바꿔주세요.
             'issue_comments': 1
         }
+        self.SESSION = requests.Session()
+        self.SESSION.headers.update({'Authorization': token}) if token else None
 
     def collect_PRs_and_issues(self) -> None:
         """
@@ -33,7 +35,8 @@ class RepoAnalyzer:
         while True:
             url = f"https://api.github.com/repos/{self.repo_path}/issues"
 
-            response = retry_request(url,
+            response = retry_request(self.SESSION,
+                                    url,
                                     max_retries=3,
                                     params={
                                         'state': 'all',
@@ -90,7 +93,6 @@ class RepoAnalyzer:
     def calculate_scores(self) -> Dict:
         """Calculate participation scores for each contributor using the refactored formula"""
         scores = {}
-        # global scores_temp
         for participant, activities in self.participants.items():
             p_f = activities.get('p_enhancement', 0)
             p_b = activities.get('p_bug', 0)

--- a/reposcore/utils/retry_request.py
+++ b/reposcore/utils/retry_request.py
@@ -2,13 +2,13 @@ import requests
 import time
 
 
-def retry_request(url, max_retries=3, retry_delay=1, params=None, headers=None) -> requests.Response:
+def retry_request(session: requests.Session, url: str, max_retries: int = 3, retry_delay: float = 1, params=None, headers=None) -> requests.Response:
     """
     주어진 URL에 대해 최대 max_retries 횟수만큼 요청을 재시도합니다.
     """
     response = None
     for i in range(max_retries):
-        response = requests.get(url, params=params, headers=headers)
+        response = session.get(url, params=params, headers=headers)
         if response.status_code == 200:
             return response
         elif i < max_retries - 1:


### PR DESCRIPTION
#301 [FEAT] GitHub API 요청 시 비로그인 유저 rate limit 초과 문제 개선 

Specify version (commit id)  https://github.com/oss2025hnu/reposcore-py/commit/c2150811da229e82f92013d022ed4174a010affe

**변경사항**
- REST API에 대한 인증로직 추가