### PR TITLE
[FIX] make readme 실패에 대한 오류 메시지 추가

### DIFF
--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -2,13 +2,22 @@
 import subprocess
 import jinja2
 import os
+import sys
 
-# 1) --help 출력
-help_text = subprocess.run(
-    ["python", "-m", "reposcore", "--help"],
-    capture_output=True,
-    text=True
-).stdout
+# 1) --help 출력 시도
+try:
+    help_result = subprocess.run(
+        ["python", "-m", "reposcore", "--help"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    help_text = help_result.stdout.strip()
+except subprocess.CalledProcessError as e: 
+    print(e.stderr or e.stdout)
+    print("❌ Failed to get help text from 'reposcore':")
+    print("❌ Failed to generate README.md from template_README.md")
+    sys.exit(1)
 
 # 2) 템플릿 로드
 template_path = os.path.join(os.path.dirname(__file__), "..", "template_README.md")
@@ -16,7 +25,7 @@ with open(template_path, encoding="utf-8") as f:
     template = jinja2.Template(f.read())
 
 # 3) 렌더링 & 저장
-rendered = template.render(usage=help_text.strip())
+rendered = template.render(usage=help_text)
 readme_path = os.path.join(os.path.dirname(__file__), "..", "README.md")
 with open(readme_path, "w", encoding="utf-8") as f:
     f.write(rendered)


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/331 make readme 실패에 대한 피드백이 안됨에 대한 PR입니다.

Specify version (commit id) 
9b95ad23d163106dbb6fad309748a2c77577a7af

## 변경 사항
- --help 명령어가 실패해도 `README.md` 를 생성하고 성공 메시지를 출력하는 문제가 있었습니다.
이제는 명령어 실패 시 에러 메시지를 출력하고 `README.md` 파일을 갱신하지 않습니다.