### PR TITLE
너무 많은 사람들의 점수가 0점으로 계산됨 을 수정함

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -124,7 +124,7 @@ class RepoAnalyzer:
             i_d = activities.get('i_documentation', 0)
             i_fb = i_f + i_b
 
-            p_valid = p_fb + min(p_d, 3 * p_fb)
+            p_valid = p_fb + min(p_d, 3 * max(1, p_fb))
             i_valid = min(i_fb + i_d, 4 * p_valid)
 
             p_fb_at = min(p_fb, p_valid)


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/360 해당 이슈에서 발생했던  score formula 공식을 수정하였습니다.

Version (commit id)
7f0661c274e668a469cbd33c74c4d6812fb96cd8

수정내용
analyzer.py 에서 score formula 공식 중 pvaild 값 때문에 거의 대부분 학생들의 점수가 0으로 되어 있는 것을 확인하였습니다.
그래서 실습수업시간때 교수님께서 공개적으로 알려주신 공식을 이용하여 대부분 학생들이 0점이 나오지 않도록 수정했습니다.(명령어를 사용해봤는데 여전히 0점으로 나온 학생이 4명 나옵니다.)