### PR TITLE
[BUG] 기능/버그 PR이 0개일 때 문서 PR 점수 미반영 및 p_d_at 계산 오류 수정 PR입니다

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -41,8 +41,7 @@ class RepoAnalyzer:
 
             
 
-            response = retry_request(self.SESSION, 
-                                     url,
+            response = retry_request(self.SESSION, url,
                                      max_retries=3,
                                      params={
                                          'state': 'all',
@@ -124,11 +123,11 @@ class RepoAnalyzer:
             i_d = activities.get('i_documentation', 0)
             i_fb = i_f + i_b
 
-            p_valid = p_fb + min(p_d, 3 * p_fb)
+            p_valid = p_fb + min(p_d, 3)
             i_valid = min(i_fb + i_d, 4 * p_valid)
 
             p_fb_at = min(p_fb, p_valid)
-            p_d_at = p_valid - p_fb
+            p_d_at = p_valid - p_fb_at
 
             i_fb_at = min(i_fb, i_valid)
             i_d_at = i_valid - i_fb_at


### PR DESCRIPTION

[BUG] 기능/버그 PR이 0개일 때 문서 PR 점수 미반영 및 p_d_at 계산 오류 https://github.com/oss2025hnu/reposcore-py/issues/392

Specify version (commit id) 
145ecb1642ed4180054f6ca4a056ea06ddbd38f1

변경사항

p_valid 계산:
p_valid에서 p_d(문서 PR)에 대한 점수는 최대 3개까지 인정되도록 min(p_d, 3)으로 수정했습니다.

p_d_at 계산:
p_d_at은 이제 p_valid에서 p_fb_at을 뺀 값으로 계산됩니다. 이렇게 수정하여 문서 PR만 있는 경우에도 점수가 0점이 아닌 3점을 최대한 인정받을 수 있도록 했습니다.