### PR TITLE
[FEAT] CLI 진입점 및 인수 처리기능 추가/검증

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -151,17 +151,17 @@ def main():
         if args.format in ["table", "text", "all"]:
             table_path = os.path.join(output_dir, "table.csv")
             analyzer.generate_table(scores, save_path=table_path)
-            print(f"\nThe table has been saved as 'table.csv' in the '{output_dir}' directory.")
+            print(f"\n csv 저장 완료: {table_path}")
 
         if args.format in ["text", "all"]:
             txt_path = os.path.join(output_dir, "table.txt")
             analyzer.generate_text(scores,txt_path)
-            print(f"\nThe table has been saved as 'table.txt' in the '{output_dir}' directory.")
+            print(f"\n 텍스트 저장 완료: {txt_path}")
 
         if args.format in ["chart", "all"]:
             chart_path = os.path.join(output_dir, "chart.png")
             analyzer.generate_chart(scores, save_path=chart_path)
-            print(f"\nThe chart has been saved as 'chart.png' in the '{output_dir}' directory.")
+            print(f"\n 차트 이미지가 저장되었습니다: {chart_path}")
 
     except Exception as e:
         print(f"Error: {str(e)}", file=sys.stderr)

--- a/reposcore/utils/validators.py
+++ b/reposcore/utils/validators.py
@@ -1,14 +1,5 @@
 import re
-
-# requests 설치 확인 및 자동 설치
-try:
-    import requests
-except ImportError:
-    import subprocess
-    import sys
-    print("requests 패키지가 설치되지 않아 설치를 시도합니다...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
-    import requests
+import requests
 
 def validate_repo_format(repo: str) -> bool:
     pattern = r'^[\w\-]+/[\w\-]+$'

--- a/reposcore/utils/validators.py
+++ b/reposcore/utils/validators.py
@@ -1,0 +1,33 @@
+import re
+
+# requests 설치 확인 및 자동 설치
+try:
+    import requests
+except ImportError:
+    import subprocess
+    import sys
+    print("requests 패키지가 설치되지 않아 설치를 시도합니다...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+    import requests
+
+def validate_repo_format(repo: str) -> bool:
+    pattern = r'^[\w\-]+/[\w\-]+$'
+    if re.fullmatch(pattern, repo):
+        return True
+    else:
+        print("저장소 형식이 올바르지 않습니다. 'owner/repo' 형식으로 입력해주세요.")
+        return False
+
+def check_github_repo_exists(repo: str) -> bool:
+     url = f"https://api.github.com/repos/{repo}"
+    
+    try:
+        response = requests.get(url)
+        if response.status_code == 200:
+            return True
+        else:
+            print(f"GitHub 저장소 '{repo}'를 찾을 수 없습니다. (응답 코드: {response.status_code})")
+            return False
+    except requests.exceptions.RequestException as e:
+        print(f"GitHub API 요청 중 오류가 발생했습니다: {e}")
+        return False


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/295
해당건에 대한 pr입니다.

1번, 2번 : reposcore/utils/validators.py 파일을 새로 생성하여 해결하였습니다.
코드 설명 : 
- requests는 외부 라이브러리이기에 requests가 설치 되어있는지 확인하고 없다면 자동으로 설치하는 과정 추가
- 사용자가 입력한 저장소 이름이 owner/repo 형식을 따르는지 확인. 일치하지 않을 시 경고문 출력
- Github api를 통해 입력한 저장소가 실제하는지 확인, 맞지 않을시 경고문 출력

4번 : 이미 main.py에 호출객체, 예외처리, 실패대응까지 되어있습니다.
5번 역시 이미 main.py에 기능이 구현되어 있었음. 결과 출력이 영문인데다 불필요하게 긴 문장{output_dir} directory으로 작성된 듯 하여 {_path} 명령어로 가독성을 높였음.

6번 : main에 작성된 코드들이 이미 원활하게 흐름에 맞게 진행되고 있는것으로 보임. 별도의 작업이 필요 없다고 판단하였습니다.