### PR TITLE
GitHub API 남은 요청 횟수 확인 기능 #385

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -18,26 +18,24 @@ class FriendlyArgumentParser(argparse.ArgumentParser):
             print(f"❌ 인자 오류: {message}")
             print("사용 가능한 --format 값: table, text, chart, all")
         else:
-            # 그 외의 옵션들에 대해서는 기본적인 오류 메시지 출력
-            super().error(message)  # 기본 오류 메시지 호출
-        sys.exit(2)  # 오류 코드 2로 종료
-    
+            super().error(message)
+        sys.exit(2)
+
 def validate_repo_format(repo: str) -> bool:
     """Check if the repo input follows 'owner/repo' format"""
-    parts = repo.split("/")  # '/'를 기준으로 분리 (예: 'oss2025hnu/reposcore-py' → ['oss2025hnu', 'reposcore-py'])
-    return len(parts) == 2 and all(parts)  # 두 개의 부분(owner, repo)이 존재해야 하고, 비어 있으면 안 됨
+    parts = repo.split("/")  # 예: 'oss2025hnu/reposcore-py' → ['oss2025hnu', 'reposcore-py']
+    return len(parts) == 2 and all(parts)
 
 def check_github_repo_exists(repo: str) -> bool:
     """Check if the given GitHub repository exists"""
-    url = f"https://api.github.com/repos/{repo}"  # 예: 'oss2025hnu/reposcore-py' → 'https://api.github.com/repos/oss2025hnu/reposcore-py'
-    response = requests.get(url)  # API 요청 보내기
-    # 💡 인증 없이 요청했을 때 제한 초과 안내
+    url = f"https://api.github.com/repos/{repo}"
+    response = requests.get(url)
+    # 인증 없이 요청했을 때 제한 초과 안내
     if response.status_code == 403:
         print("⚠️ GitHub API 요청 실패: 403 (비인증 상태로 요청 횟수 초과일 수 있습니다.)")
         print("ℹ️ 해결 방법: --token 옵션으로 GitHub Access Token을 전달해보세요.")
         return False
-    
-    return response.status_code == 200  # 응답코드가 정상이면 저장소가 존재함
+    return response.status_code == 200
 
 def check_rate_limit(token: Optional[str] = None) -> None:
     """현재 GitHub API 요청 가능 횟수와 전체 한도를 확인하고 출력하는 함수"""
@@ -58,21 +56,22 @@ def parse_arguments() -> argparse.Namespace:
     """커맨드라인 인자를 파싱하는 함수"""
     parser = FriendlyArgumentParser(
         prog="python -m reposcore",
-        usage="python -m reposcore [-h] owner/repo [--output dir_name] [--format {table,text,chart,all}] [--check-limit]",
+        usage="python -m reposcore [-h] [owner/repo] [--output dir_name] [--format {table,text,chart,all}] [--check-limit]",
         description="오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구",
-        add_help=False  # 기본 --help 옵션을 비활성화
+        add_help=False
     )
-    
     parser.add_argument(
         "-h", "--help",
         action="help",
         help="도움말 표시 후 종료"
     )
+    # repository 인자를 optional로 설정 (nargs="?")
     parser.add_argument(
         "repository",
         type=str,
+        nargs="?",
         metavar="owner/repo",
-        help="분석할 GitHub 저장소 (형식: '소유자/저장소')"
+        help="분석할 GitHub 저장소 (형식: '소유자/저장소'). --check-limit 옵션 사용 시 생략 가능"
     )
     parser.add_argument(
         "--output",
@@ -86,7 +85,7 @@ def parse_arguments() -> argparse.Namespace:
         choices=["table", "text", "chart", "all"],
         default="all",
         metavar="{table,text,chart,all}",
-        help="결과 출력 형식 선택 (테이블: 'table', 텍스트 : 'text', 차트: 'chart', 모두 : 'all')"
+        help="결과 출력 형식 선택 (테이블: 'table', 텍스트: 'text', 차트: 'chart', 모두: 'all')"
     )
     parser.add_argument(
         "--use-cache",
@@ -103,7 +102,6 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="현재 GitHub API 요청 가능 횟수와 전체 한도를 확인합니다."
     )
-
     return parser.parse_args()
 
 def main():
@@ -111,38 +109,34 @@ def main():
     args = parse_arguments()
     github_token = args.token
 
+    # 토큰 값은 커맨드라인 옵션, 환경변수, 또는 표준 입력에서 받아올 수 있음
     if not args.token:
         github_token = os.getenv('GITHUB_TOKEN')
     elif args.token == '-':
         github_token = sys.stdin.readline().strip()
 
-    # --check-limit 옵션 처리: 옵션이 있으면 API 요청 한도 정보 확인 후 종료
+    # --check-limit 옵션 처리: 옵션이 주어지면 repository 인자 없이도 실행됨.
     if args.check_limit:
         check_rate_limit(token=github_token)
         sys.exit(0)
 
-    # Validate repo format
-    if not validate_repo_format(args.repository):
-        print("오류 : 저장소는 'owner/repo' 형식으로 입력해야 함. 예) 'oss2025hnu/reposcore-py'")
+    # --check-limit 옵션이 없을 경우, repository 인자는 필수
+    if not args.repository or not validate_repo_format(args.repository):
+        print("오류: 저장소는 'owner/repo' 형식으로 입력해야 함. 예) 'oss2025hnu/reposcore-py'")
         sys.exit(1)
 
-    # (Optional) Check if the repository exists on GitHub
     if not check_github_repo_exists(args.repository):
-        print(f"입력한 저장소 '{args.repository}' 가 깃허브에 존재하지 않을 수 있음.")
-    
-    print(f"저장소 분석 시작 : {args.repository}")
+        print(f"입력한 저장소 '{args.repository}'가 깃허브에 존재하지 않을 수 있음.")
 
-    # Initialize analyzer
+    print(f"저장소 분석 시작: {args.repository}")
+
     analyzer = RepoAnalyzer(args.repository, token=github_token)
 
-    # 디렉토리 먼저 생성
     output_dir = args.output
     os.makedirs(output_dir, exist_ok=True)
 
-    # 캐시 파일 경로 설정
     cache_path = os.path.join(output_dir, "cache.json")
 
-    # 캐시 처리
     if args.use_cache and os.path.exists(cache_path):
         print("✅ 캐시 파일이 존재합니다. 캐시에서 데이터를 불러옵니다.")
         import json
@@ -151,24 +145,18 @@ def main():
     else:
         print("🔄 캐시를 사용하지 않거나 캐시 파일이 없습니다. GitHub API로 데이터를 수집합니다.")
         analyzer.collect_PRs_and_issues()
-        # 통신 실패 시 처리
         if not getattr(analyzer, "_data_collected", True):
             print("❌ GitHub API 요청에 실패했습니다. 결과 파일을 생성하지 않고 종료합니다.")
             print("ℹ️ 인증 없이 실행한 경우 요청 횟수 제한(403)일 수 있습니다. --token 옵션을 사용해보세요.")
             sys.exit(1)
-
         import json
         with open(cache_path, "w", encoding="utf-8") as f:
             json.dump(analyzer.participants, f, indent=2, ensure_ascii=False)
 
     try:
-        # Calculate scores
         scores = analyzer.calculate_scores()
-
-        output_dir = args.output
         os.makedirs(output_dir, exist_ok=True)
 
-        # Generate outputs based on format
         if args.format in ["table", "text", "all"]:
             table_path = os.path.join(output_dir, "table.csv")
             analyzer.generate_table(scores, save_path=table_path)

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -109,18 +109,17 @@ def main():
     args = parse_arguments()
     github_token = args.token
 
-    # 토큰 값은 커맨드라인 옵션, 환경변수, 또는 표준 입력에서 받아올 수 있음
     if not args.token:
         github_token = os.getenv('GITHUB_TOKEN')
     elif args.token == '-':
         github_token = sys.stdin.readline().strip()
 
-    # --check-limit 옵션 처리: 옵션이 주어지면 repository 인자 없이도 실행됨.
+    # --check-limit 옵션 처리: 이 옵션이 있으면 repository 인자 없이 실행됨.
     if args.check_limit:
         check_rate_limit(token=github_token)
         sys.exit(0)
 
-    # --check-limit 옵션이 없을 경우, repository 인자는 필수
+    # --check-limit 옵션이 없으면 repository 인자는 필수임.
     if not args.repository or not validate_repo_format(args.repository):
         print("오류: 저장소는 'owner/repo' 형식으로 입력해야 함. 예) 'oss2025hnu/reposcore-py'")
         sys.exit(1)

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -65,11 +65,12 @@ def parse_arguments() -> argparse.Namespace:
         action="help",
         help="도움말 표시 후 종료"
     )
-    # repository 인자를 optional로 설정 (nargs="?")
+    # repository 인자를 optional로 설정(nargs="?") 및 default="" 지정
     parser.add_argument(
         "repository",
         type=str,
         nargs="?",
+        default="",
         metavar="owner/repo",
         help="분석할 GitHub 저장소 (형식: '소유자/저장소'). --check-limit 옵션 사용 시 생략 가능"
     )


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/385
GitHub API 남은 요청 횟수 확인 기능에 대한 pr입니다!
Specify version (commit id) 47014fe
826916aadded660ba2f4f6154da5030ac846a6c5
변경사항
1.새로운 --check-limit 옵션을 추가하여 사용자가 GitHub API의 현재 잔여 요청 수와 전체 한도를 확인할 수 있도록 했습니다.
(이 옵션이 활성화되면 저장소 인자(예: "owner/repo") 없이도 명령어를 실행할 수 있도록 했습니다,
단  --check-limit 옵션이 없는 경우에는 repository 인자가 필요하며 "API 요청 제한 정보를 가져오는데 실패했습니다"라는 오류가 뜨게 함)
2."사용자가 원할 때만 확인할 수 있도록 선택적 옵션으로 구현"을 위해 잔여횟수를 확안 한 후
reposcore 프로그램이 종료되어 명령 실행이 끝나고 터미널은 다시 커맨드 프롬프트 상태로 돌아도록 작성하였습니다

추가적인 이해를 위해 테스트사진 첨부
<img width="572" alt="image" src="https://github.com/user-attachments/assets/e165e26c-1155-4c98-8c64-8c32d77c5ffb" />
(위의 사진처럼 "python -m reposcore --check-limit"명령어 입력시 횟수 확인 가능)
