### PR TITLE
[BUG] --format 옵션 설명에 잘못된 예시값 PR

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -69,7 +69,7 @@ def parse_arguments() -> argparse.Namespace:
         "--format",
         choices=["table", "text", "chart", "all"],
         default="all",
-        metavar="{table,text,chart,both}",
+        metavar="{table,text,chart,all}",
         help = "결과 출력 형식 선택 (테이블: 'table', 텍스트 : 'text', 차트: 'chart', 모두 : 'all')"
     )
 


### PR DESCRIPTION
[BUG] --format 옵션 설명에 잘못된 예시값에 대한 PR입니다. (https://github.com/oss2025hnu/reposcore-py/issues/383)

Specify version (commit id)

https://github.com/oss2025hnu/reposcore-py/commit/07b9d5753241b491c954abe27ea28ebc8660b8ad

변경사항
기존에 --format 옵션의 metavar가 [table|chart|both]로 되어 있었으나,
실제 허용되는 값은 "table", "chart", "all"입니다.
따라서 사용자 혼란을 줄이기 위해 metavar를 [table|chart|all]로 수정하였습니다.