### PR TITLE
[BUG] 실행 후 생성되는 table.txt파일 관리에 대한 PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,4 @@ cython_debug/
 *.csv
 *.png
 cache.json
-
+table.txt


### PR DESCRIPTION
[BUG] 실행 후 생성되는 table.txt파일 관리에 대한 PR입니. (https://github.com/oss2025hnu/reposcore-py/issues/401)

Specify version (commit id)
https://github.com/oss2025hnu/reposcore-py/commit/92b8527f9139a390b4ed6490b8672ec5caacc8ad

변경사항
table.txt는 실행 결과물로, PR에 포함될 필요가 없으므로 .gitignore에 추가하였습니다.