### PR TITLE
[FEAT] csv 파일의 첫 번째 열에 name 컬럼 추가

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -155,9 +155,10 @@ class RepoAnalyzer:
         return dict(sorted(scores.items(), key=lambda x: x[1]["total"], reverse=True))
 
     def generate_table(self, scores: Dict, save_path) -> None:
-        """Generate a table of participation scores"""
         df = pd.DataFrame.from_dict(scores, orient="index")
-        df.to_csv(save_path)
+        df.reset_index(inplace=True)
+        df.rename(columns={"index": "name"}, inplace=True)
+        df.to_csv(save_path, index=False)
 
     def generate_text(self, scores: Dict, save_path) -> None:
         """Generate a table of participation scores"""


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/393 csv 파일의 첫 번째 열에 name 컬럼 추가에 대한 PR입니다.

Specify version (commit id). 
92b8527f9139a390b4ed6490b8672ec5caacc8ad

## 변경사항
- csv 파일의 첫 번째 열에 name 컬럼 추가되어 다음과 같이 출력됩니다.
- `name,feat/bug PR,document PR,feat/bug issue,document issue,total,rate`