### PR TITLE
[FEAT] chart.png에 참가자 수를 표시하는 기능 추가 요청에 대한 PR

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -194,6 +194,7 @@ class RepoAnalyzer:
 
         plt.xlabel('Participation Score')
         plt.title('Repository Participation Scores')
+        plt.suptitle(f"Total Participants: {num_participants}", fontsize=10, x=0.98, ha='right')
         plt.gca().invert_yaxis()
 
         for bar in bars:


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/406
[FEAT] chart.png에 참가자 수를 표시하는 기능 추가 요청에 대한 PR입니다.

Specify version (commit id).
3929319323a3408f2b86beef8a7d7d92c8aba90a

변경사항
generate_chart()에 코드를 추가하여 chart.png 상단 오른쪽에 전체 참가자 인원 수를 표시하는 기능을 추가하였습니다.
이 기능을 추가함으로 몇 명이 프로젝트에 참여하고 있는지 알 수 있습니다.