### PR TITLE
[FEAT] --format옵션 중복 선택이 가능하도록 개선 요청 

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -89,9 +89,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--format",
         choices=["table", "text", "chart", "all"],
-        default="all",
+        nargs='+',
+        default=["all"],
         metavar="{table,text,chart,all}",
-        help = "결과 출력 형식 선택 (테이블: 'table', 텍스트 : 'text', 차트: 'chart', 모두 : 'all')"
+        help = "결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart). 옵션: 'table', 'text', 'chart', 'all'"
     )
     parser.add_argument(
         "--use-cache",
@@ -163,20 +164,23 @@ def main():
 
     try:
         scores = analyzer.calculate_scores()
+        formats = set(args.format)
 
         # Generate outputs based on format
+        if "all" in formats:
+            formats =  {"table", "text", "chart"}
 
-        if args.format in ["table", "text", "all"]:
+        if "table" in formats:
             table_path = os.path.join(output_dir, "table.csv")
             analyzer.generate_table(scores, save_path=table_path)
             log(f"\n csv 저장 완료: {table_path}")
 
-        if args.format in ["text", "all"]:
+        if "text" in formats:
             txt_path = os.path.join(output_dir, "table.txt")
             analyzer.generate_text(scores,txt_path)
             log(f"\n 텍스트 저장 완료: {txt_path}")
             
-        if args.format in ["chart", "all"]:
+        if "chart" in formats:
             chart_path = os.path.join(output_dir, "chart.png")
             analyzer.generate_chart(scores, save_path=chart_path)
             log(f"\n 차트 이미지가 저장되었습니다: {chart_path}")


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/433 에 대한 pr입니다.

--format 옵션을 복수 선택 가능하도록 개선했습니다.
ex) --format table chart 또는 --format text

"all"을 입력하면 기존처럼 세 가지 결과가 모두 출력됩니다.

내부에서는 set 자료형을 사용해 중복 제거 및 조건 검사를 개선했습니다.

도움말 메시지(--help)를 수정했습니다.