### PR TITLE
[DOC] 채점 공식 수정: 기능/버그 PR 0건 시 문서 PR 최대 3건 인정되도록 P_valid 수정 에대한 readme 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ python -m reposcore [OPTIONS]
 ```
 
 ```
-usage: python -m reposcore [-h] [owner/repo] [--output dir_name] [--format {table,text,chart,all}] [--check-limit]
+usage: python -m reposcore [-h] [owner/repo ...] [--output dir_name] [--format {table,text,chart,all}] [--check-limit]
 
 오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구
 
 positional arguments:
-  owner/repo            분석할 GitHub 저장소 (형식: '소유자/저장소'). --check-limit 옵션 사용 시
-                        생략 가능
+  owner/repo            분석할 GitHub 저장소들 (형식: '소유자/저장소'). 여러 저장소의 경우 공백 혹은 쉼표로
+                        구분하여 입력
 
 options:
   -h, --help            도움말 표시 후 종료
   --output dir_name     분석 결과를 저장할 출력 디렉토리 (기본값: 'results')
-  --format {table,text,chart,all}
-                        결과 출력 형식 선택 (테이블: 'table', 텍스트 : 'text', 차트: 'chart',
-                        모두 : 'all')
+  --format {table,text,chart,all} [{table,text,chart,all} ...]
+                        결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart). 옵션:
+                        'table', 'text', 'chart', 'all'
   --use-cache           participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)
   --token TOKEN         API 요청 제한 해제를 위한 깃허브 개인 액세스 토큰
   --check-limit         현재 GitHub API 요청 가능 횟수와 전체 한도를 확인합니다.
@@ -74,10 +74,11 @@ options:
 - $I_{fb}$ : 기능 또는 버그 관련 Open 또는 해결된 이슈 개수 (**2점**) ($I_{fb} = I_f + I_b$)  
 - $I_d$ : 문서 관련 Open 또는 해결된 이슈 개수 (**1점**)
 
-$P_{\text{valid}} = P_{fb} + \min(P_d, 3P_{fb}) ~~\quad$ 점수 인정 가능 PR 개수\
+$P_{\text{valid}} = P_{fb} + \min(P_d, 3 \times \max(P_{fb}, 1)) \quad$ 점수 인정 가능 PR 개수
 $I_{\text{valid}} = \min(I_{fb} + I_d, 4 \times P_{\text{valid}}) \quad$ 점수 인정 가능 이슈 개수
 
 PR의 점수를 최대로 하기 위해 기능/버그 PR을 먼저 계산한 후 문서 PR을 계산합니다.
+(p_fb이 0일 경우에도 문서 PR 최대 3개까지 인정됩니다.)
 
 $P_{fb}^* = \min(P_{fb}, P_{\text{valid}}) \quad$ 기능/버그 PR 최대 포함\
 $P_d^* = P_{\text{valid}} - P_{fb}^* ~~\quad$ 남은 개수에서 문서 PR 포함

--- a/template_README.md
+++ b/template_README.md
@@ -58,10 +58,11 @@ python -m reposcore [OPTIONS]
 - $I_{fb}$ : 기능 또는 버그 관련 Open 또는 해결된 이슈 개수 (**2점**) ($I_{fb} = I_f + I_b$)  
 - $I_d$ : 문서 관련 Open 또는 해결된 이슈 개수 (**1점**)
 
-$P_{\text{valid}} = P_{fb} + \min(P_d, 3P_{fb}) ~~\quad$ 점수 인정 가능 PR 개수\
+$P_{\text{valid}} = P_{fb} + \min(P_d, 3 \times \max(P_{fb}, 1)) \quad$ 점수 인정 가능 PR 개수
 $I_{\text{valid}} = \min(I_{fb} + I_d, 4 \times P_{\text{valid}}) \quad$ 점수 인정 가능 이슈 개수
 
 PR의 점수를 최대로 하기 위해 기능/버그 PR을 먼저 계산한 후 문서 PR을 계산합니다.
+(p_fb이 0일 경우에도 문서 PR 최대 3개까지 인정됩니다.)
 
 $P_{fb}^* = \min(P_{fb}, P_{\text{valid}}) \quad$ 기능/버그 PR 최대 포함\
 $P_d^* = P_{\text{valid}} - P_{fb}^* ~~\quad$ 남은 개수에서 문서 PR 포함


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/390
코드만 수정하고 readme에는 반영되지 않은것을 수정했습니다.

저는 $P_{\text{valid}} = P_{fb} + \min(P_d, 3 \times \max(P_{fb}, 1)) \quad$ 점수 인정 가능 PR 개수
(p_fb이 0일 경우에도 문서 PR 최대 3개까지 인정됩니다.)
두 줄만 수정했는데 readme.md의  다른 부분도 같이 수정된것으로 보아 이전 사용자가 template_README.md를 실행하고 이를 readme에 반영하지 않았던것 같습니다.