### PR TITLE
한국 시간대 설정 가이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ $S = 3P_{fb}^* + 2P_d^* + 2I_{fb}^* + 1I_d^*$
 ## 토큰 생성 방법
 👉 [토큰 생성 방법](docs/github-token-guide.md) 문서를 참고 부탁드립니다.
 
+## 한국 시간대(Asia/Seoul) 설정 가이드
+👉 [한국 시간대(Asia/Seoul) 설정 가이드](docs/korean-timezone-guide.md) 문서를 참고 부탁드립니다.
+
 ## 프로젝트 작성 시 주의사항
 👉 [프로젝트 작성 시 주의사항](docs/project_guidelines.md) 문서를 참고 부탁드립니다.
 ```

--- a/docs/korean-timezone-guide.md
+++ b/docs/korean-timezone-guide.md
@@ -1,0 +1,42 @@
+## 한국 시간대(Asia/Seoul) 설정 가이드
+
+
+### Codespaces에서 한국 시간대 적용하기
+
+Codespaces 터미널에서 아래 명령어를 입력하세요:
+
+```bash
+export TZ=Asia/Seoul
+```
+
+또는 `.bashrc` / `.zshrc` 파일에 아래 내용을 추가하면 자동 적용됩니다:
+
+```bash
+echo 'export TZ=Asia/Seoul' >> ~/.bashrc
+source ~/.bashrc
+```
+
+---
+
+### GitHub Actions에서 시간대 변경하기
+
+`.github/workflows/ci.yml` 같은 워크플로우 파일에 다음을 추가합니다:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set timezone to Asia/Seoul
+        run: |
+          sudo ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
+          echo "Asia/Seoul" | sudo tee /etc/timezone
+```
+
+---
+
+### 주의사항
+
+- Python `datetime.now()`는 OS의 기본 시간대를 따르므로 위 설정이 되어 있어야 한국 시간으로 로그가 표시됩니다.
+- 시스템 시간 설정이 불가한 환경이라면 `datetime.now(tz=...)` 사용을 고려할 수 있습니다.
+

--- a/template_README.md
+++ b/template_README.md
@@ -81,6 +81,9 @@ $S = 3P_{fb}^* + 2P_d^* + 2I_{fb}^* + 1I_d^*$
 ## 토큰 생성 방법
 👉 [토큰 생성 방법](docs/github-token-guide.md) 문서를 참고 부탁드립니다.
 
+## 한국 시간대(Asia/Seoul) 설정 가이드
+👉 [한국 시간대(Asia/Seoul) 설정 가이드](docs/korean-timezone-guide.md) 문서를 참고 부탁드립니다.
+
 ## 프로젝트 작성 시 주의사항
 👉 [프로젝트 작성 시 주의사항](docs/project_guidelines.md) 문서를 참고 부탁드립니다.
 ```


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/441 에 대한PR

Specify version (commit id)
https://github.com/oss2025hnu/reposcore-py/commit/c7412e177aa74cd4d17857b8a3852dae665b99d8

**변경사항**
- `docs/korean-timezone-guide.md`  파일 추가
- `README.md` 하단에 링크 삽입
- Codespaces 및 GitHub Actions 환경에서 Asia/Seoul 시간대로 설정하는 방법 문서화
- export TZ=Asia/Seoul 사용법 포함
- CI 환경에서 시간대를 변경하는 YAML 설정 예시 포함