### PR TITLE
[FIX] test_main_without_repo_option 함수의 에러 메시지 포함 조견 변경

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,7 +31,7 @@ def test_main_without_repo_option():
         text=True
     )
     assert result.returncode != 0
-    assert "repo 옵션은 'owner/repo' 형식으로 입력해야 함" in result.stdout or "required" in result.stderr
+    assert "'owner/repo' 형식으로" in result.stdout or "required" in result.stderr
 
 # def test_main_invalid_repo_format():
 #     """잘못된 형식의 repo 인자에 대한 처리"""


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/430 test_main_without_repo_option 실패에 대한 PR입니다.

Specify version (commit id).
acdf195fcf42b3ca421ac89ce5c7f549cbba7732

## 변경사항
- 에러 메시지가 `log(f"오류: 저장소 '{repo}'는 'owner/repo' 형식으로 입력해야 합니다. 예) 'oss2025hnu/reposcore-py'")`로 변경되어 `test_main_without_repo_option` 함수의 에러 메시지 포함 조건을 다음과 같이 변경했습니다.
- ` assert "'owner/repo' 형식으로" in result.stdout or "required" in result.stderr`