### PR TITLE
[FEAT] 토큰이 잘못 입력 되었을 때 이를 알려주는 코드가 없습니다.에 대한 pr입니다.

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -80,7 +80,11 @@ class RepoAnalyzer:
                                          'per_page': per_page,
                                          'page': page
                                      })
-            if response.status_code == 403:
+            if response.status_code == 401:
+                log("❌ 인증 실패: 잘못된 GitHub 토큰입니다. 토큰 값을 확인해 주세요.")
+                self._data_collected = False
+                return
+            elif response.status_code == 403:
                 log("⚠️ 요청 실패 (403): GitHub API rate limit에 도달했습니다.")
                 log("🔑 토큰 없이 실행하면 1시간에 최대 60회 요청만 허용됩니다.")
                 log("💡 해결법: --api-key 옵션으로 GitHub 개인 액세스 토큰을 설정해 주세요.")


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/457 에 대한 pr입니다.

Specify version (commit id).
a4584de1c2dc4ab9d1d5916f5017b9670ed90e1f

response.status_code == 401:를 추가하고 이와 같이 출력되도록 작성했습니다.

`❌ 인증 실패: 잘못된 GitHub 토큰입니다. 토큰 값을 확인해 주세요.`