### PR TITLE
[FEAT] Repository List Parsing 코드 리팩토링

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -138,14 +138,9 @@ def main():
 
     repositories: List[str] = args.repository
     # 쉼표로 여러 저장소가 입력된 경우 분리
-    final_repositories = []
-    for repo in repositories:
-        if "," in repo:
-            final_repositories.extend([r.strip() for r in repo.split(",") if r.strip()])
-        else:
-            final_repositories.append(repo)
-    # 중복 제거
-    final_repositories = list(dict.fromkeys(final_repositories))
+    final_repositories = list(dict.fromkeys(
+    [r.strip() for repo in repositories for r in repo.split(",") if r.strip()]
+    ))
 
     # 각 저장소 유효성 검사
     for repo in final_repositories:


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/452

저장소 인자 처리 시 쉼표로 분리하는 로직이 여러 줄로 중복 작성되어 있어, 코드 가독성과 유지보수성이 떨어집니다. 
다음 한 줄의 List Comprehension으로 간결하게 수정하였습니다.

6cfe9344ed98a9bf2fa5b7e64e6fbf9b7558db3a

✅ 변경 전
```
final_repositories = []
for repo in repositories:
    if "," in repo:
        final_repositories.extend([r.strip() for r in repo.split(",") if r.strip()])
    else:
        final_repositories.append(repo)
final_repositories = list(dict.fromkeys(final_repositories))  # ❌ 이 줄 포함
```

✅변경 후(한 줄)
```
final_repositories = list(dict.fromkeys(
    [r.strip() for repo in repositories for r in repo.split(",") if r.strip()]
))
```



