### PR TITLE
[FEAT] 사용자의 정보를 사전에 입력 받아 결과물 출력시 사용자의 ID를 사용자의 이름으로 치환하는 기능에 대한 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ options:
   --use-cache           participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)
   --token TOKEN         API 요청 제한 해제를 위한 깃허브 개인 액세스 토큰
   --check-limit         현재 GitHub API 요청 가능 횟수와 전체 한도를 확인합니다.
+  --user-info USER_INFO
+                        사용자 정보 파일의 경로
 ```
 
 ### 옵션 설명
@@ -105,3 +107,6 @@ $S = 3P_{fb}^* + 2P_d^* + 2I_{fb}^* + 1I_d^*$
 
 ## README.md 자동 생성 및 최신 상태 유지 가이드
 👉 [README.md 자동 생성 및 최신 상태 유지 가이드](docs/readme_version_check_guide.md) 문서를 참고 부탁드립니다.
+
+## 차트 생성시 한글 폰트 깨짐 이슈 해결 가이드
+👉 [차트 생성시 한글 폰트 깨짐 이슈 해결 가이드](docs/chart-font-guide.md) 문서를 참고 부탁드립니다.

--- a/docs/chart-font-guide.md
+++ b/docs/chart-font-guide.md
@@ -1,0 +1,14 @@
+## 차트 한글 폰트 깨짐 이슈 해결 가이드
+
+
+### 패키지 업데이트 및 패키지 설치
+```bash
+sudo apt update
+sudo apt install fonts-nanum
+```
+
+### 폰트 목록 업데이트 및 matplotlib 캐시 삭제
+```bash
+sudo fc-cache -fv
+rm ~/.cache/matplotlib/fontlist-*.json
+```

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -191,7 +191,6 @@ def main():
 
         os.makedirs(args.output, exist_ok=True)
 
-        os.makedirs(args.output, exist_ok=True)
         if "all" in formats:
             formats =  {"table", "text", "chart"}
 

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -108,6 +108,11 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="현재 GitHub API 요청 가능 횟수와 전체 한도를 확인합니다."
     )
+    parser.add_argument(
+        "--user-info",
+        type=str,
+        help="사용자 정보 파일의 경로"
+    )
     return parser.parse_args()
 
 def merge_participants(overall: dict, new_data: dict) -> dict:
@@ -186,7 +191,8 @@ def main():
     aggregator.participants = overall_participants
 
     try:
-        scores = aggregator.calculate_scores()
+        user_info = json.load(open(args.user_info, "r", encoding="utf-8")) if args.user_info and os.path.exists(args.user_info) else None
+        scores = aggregator.calculate_scores(user_info)
         formats = set(args.format)
 
         os.makedirs(args.output, exist_ok=True)

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, Optional
 import matplotlib.pyplot as plt
+
 import pandas as pd
 import requests
 from prettytable import PrettyTable
@@ -170,7 +171,7 @@ class RepoAnalyzer:
             for user, info in self.participants.items():
                 log(f"{user}: {info}")
 
-    def calculate_scores(self) -> Dict:
+    def calculate_scores(self, user_info=None) -> Dict:
         """Calculate participation scores for each contributor using the refactored formula"""
         scores = {}
         total_score_sum = 0
@@ -216,6 +217,12 @@ class RepoAnalyzer:
             total = scores[participant]["total"]
             rate = (total / total_score_sum) * 100 if total_score_sum > 0 else 0
             scores[participant]["rate"] = round(rate, 1)
+
+        if user_info:
+            for k,v in user_info.items():
+                if user_info.get(k):
+                    scores[user_info[k]] = scores.pop(k)
+
 
         return dict(sorted(scores.items(), key=lambda x: x[1]["total"], reverse=True))
 
@@ -293,6 +300,8 @@ class RepoAnalyzer:
         log(f"📝 텍스트 결과 저장 완료: {save_path}")
 
     def generate_chart(self, scores: Dict, save_path: str = "results") -> None:
+        plt.rc('font', family='NanumGothic')
+
         sorted_scores = sorted(
             [(key, value.get('total', 0)) for (key, value) in scores.items()],
             key=lambda item: item[1],


### PR DESCRIPTION
#443 [FEAT] 사용자의 정보를 사전에 입력 받아 결과물 출력시 사용자의 ID를 사용자의 이름으로 치환하는 기능 

**Specify version (commit id)**
47c8e34f80a3d2aeb32490bcb49ce008c794bf40

**변경사항**
- [불필요한 코드 제거](https://github.com/oss2025hnu/reposcore-py/commit/737b45cd556cc70ba8751f4c892374337e216317)
- [사용자의 정보를 사전에 입력 받아 결과물 출력시 사용자의 ID를 사용자의 이름으로 치환하는 기능](https://github.com/oss2025hnu/reposcore-py/commit/47c8e34f80a3d2aeb32490bcb49ce008c794bf40)