### PR TITLE
[DOC] --check-limit 옵션 내용 github_api_guide.md로 이동 요청 에 대한 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,6 @@ options:
   --check-limit         현재 GitHub API 요청 가능 횟수와 전체 한도를 확인합니다.
 ```
 
-### 옵션 설명
-
-- **--check-limit**  
-  이 옵션은 GitHub API의 **레이트 리밋 정보**를 확인하는 데 사용됩니다. `repository` 인자를 생략할 수 있으며, 이 경우 잔여 요청 횟수와 전체 한도를 출력합니다.  
-  사용 예시:  
-  ```bash
-  python -m reposcore --check-limit
-  ```
-  위 명령을 실행하면, 현재 GitHub API의 잔여 요청 횟수와 전체 한도 정보가 출력되고 프로그램이 종료됩니다. 이 옵션은 선택적 옵션으로, 사용자가 필요할 때만 호출할 수 있습니다.
-
-- **repository 인자**  
-  `--check-limit` 옵션이 없을 경우, `repository` 인자는 필수로 제공되어야 하며, 올바른 형식("owner/repo")인지 검증하는 로직이 포함되어 있습니다.  
-  사용 예시:  
-  ```bash
-  python -m reposcore owner/repo
-  ```
-  `owner/repo` 형식의 리포지토리 정보를 제공해야 합니다. 올바른 형식인지 검증이 수행됩니다.
 
 ## Test
 👉 [테스트 가이드 보기](docs/test-guide.md)

--- a/docs/github_api_guide.md
+++ b/docs/github_api_guide.md
@@ -36,18 +36,48 @@ params = {
 
 - 인증 없이: 시간당 60회 요청
 - 인증 시 (Personal Access Token): 시간당 5,000회까지 가능
-    
+
     → `Authorization: token <your_token>` 헤더로 추가해야 해요.
-    
 
 예:
 
 ```python
-session.headers.update({"Authorization": f"token {your_token}"})
-
+session.headers.update({"Authorization": f"token {your_token}"
+})
 ```
 
 [토큰 생성 방법](docs/github-token-guide.md)
+
+### ✅ `--check-limit` 옵션
+
+- 이 옵션은 GitHub API의 **잔여 요청 가능 횟수**와 **전체 한도**를 출력합니다.
+- `repository` 인자를 생략해도 사용 가능하며, 프로그램은 API 요청 없이 현재의 Rate Limit 정보만 조회하고 종료됩니다.
+
+사용 예시:
+
+```bash
+python -m reposcore --check-limit
+```
+
+출력 예:
+
+```
+GitHub API Rate Limit: 4992 / 5000 remaining
+```
+
+### ✅ `repository` 인자와 Rate Limit 관련성
+
+- GitHub 저장소(`owner/repo`)를 인자로 넘기면, 실제 데이터를 수집하기 위해 **다수의 API 호출**이 발생합니다.
+- 이때 **토큰을 설정하지 않으면** API 호출이 차단될 수 있으며, 잘못된 형식의 인자(`abcd` 또는 `repo` 등)는 오류를 발생시킵니다.
+
+예시:
+
+```bash
+python -m reposcore owner/repo  # 정상 실행
+python -m reposcore abcd        # 에러 발생 (형식 오류)
+```
+
+이런 형식 유효성 검사는 내부적으로 `owner/repo` 문자열을 검사하는 로직으로 구현되어 있습니다.
 
 ---
 
@@ -67,3 +97,4 @@ session.headers.update({"Authorization": f"token {your_token}"})
     
 2. **Python에서 `requests`로 호출해보기**
 3. **Label과 merged 상태 확인하면서 PR/Issue 분석 코드 연습**
+

--- a/template_README.md
+++ b/template_README.md
@@ -29,23 +29,6 @@ python -m reposcore [OPTIONS]
 {{ usage }}
 ```
 
-### 옵션 설명
-
-- **--check-limit**  
-  이 옵션은 GitHub API의 **레이트 리밋 정보**를 확인하는 데 사용됩니다. `repository` 인자를 생략할 수 있으며, 이 경우 잔여 요청 횟수와 전체 한도를 출력합니다.  
-  사용 예시:  
-  ```bash
-  python -m reposcore --check-limit
-  ```
-  위 명령을 실행하면, 현재 GitHub API의 잔여 요청 횟수와 전체 한도 정보가 출력되고 프로그램이 종료됩니다. 이 옵션은 선택적 옵션으로, 사용자가 필요할 때만 호출할 수 있습니다.
-
-- **repository 인자**  
-  `--check-limit` 옵션이 없을 경우, `repository` 인자는 필수로 제공되어야 하며, 올바른 형식("owner/repo")인지 검증하는 로직이 포함되어 있습니다.  
-  사용 예시:  
-  ```bash
-  python -m reposcore owner/repo
-  ```
-  `owner/repo` 형식의 리포지토리 정보를 제공해야 합니다. 올바른 형식인지 검증이 수행됩니다.
 
 ## Test
 👉 [테스트 가이드 보기](docs/test-guide.md)


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/484 [DOC] --check-limit 옵션 내용 github_api_guide.md로 이동 요청 에 대한 PR입니다.
Specify version (commit id).
 5a73a55cc0b5e1ee44f78b2b28e1d4d1108e2aa1

**변경사항**
- template_README.md 파일에 있는 --check-limit 옵션 및 repository 인자에 관한 설명을 삭제하고,
해당 내용을 docs/github_api_guide.md 파일에 추가하여 GitHub API 관련 모든 정보가 한 곳에 집중되도록 수정