### PR TITLE
[FEAT] Github Actions에 깃헙 토큰 추가 PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: 리포지토리 체크아웃
         uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/483 **[FEAT] Github Actions에 깃헙 토큰 추가에 대한 PR입니다.**

**Specify version (commit id)**
https://github.com/oss2025hnu/reposcore-py/commit/d3a91c6e65d0bb094de5e73a8e52442563361b28

**변경사항**

- `.github/workflows/ci.yaml` 워크플로우 파일 수정
- `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` 추가하여 인증된 GitHub API 호출 가능하게 변경
- PR, Push 등으로 인한 테스트 실행 시 API rate limit 초과 문제 방지