### PR TITLE
[BUG] --help옵션 사용 시 usage의 출력이 상이함에 대한 PR입니다

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -66,7 +66,7 @@ def parse_arguments() -> argparse.Namespace:
     """커맨드라인 인자를 파싱하는 함수"""
     parser = FriendlyArgumentParser(
         prog="python -m reposcore",
-        usage="python -m reposcore [-h] [owner/repo ...] [--output dir_name] [--format {table,text,chart,all}] [--check-limit]",
+        usage="python -m reposcore [-h] [owner/repo ...] [--output dir_name] [--format {table,text,chart,all}] [--check-limit] [--user-info path]",
         description="오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구",
         add_help=False
     )


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/510 [BUG] --help옵션 사용 시 usage의 출력이 상이함에 대한 PR입니다.

Specify version (commit id)

563db6170222d33767d3c74a8d1254cbdc360272

변경사항

커맨드라인 도움말(--help) 실행 시 usage에 --user-info 옵션이 누락되어 있던 문제를 해결했습니다.
argparse.ArgumentParser에서 usage 문자열을 직접 지정하는 구조였기 때문에, 수동으로 --user-info 옵션을 추가해 usage와 options 섹션 간 일관성을 맞췄습니다.