### PR TITLE
--grade 옵션 README에 사용법 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m reposcore [OPTIONS]
 ```
 
 ```
-usage: python -m reposcore [-h] [owner/repo ...] [--output dir_name] [--format {table,text,chart,all}] [--check-limit]
+usage: python -m reposcore [-h] [owner/repo ...] [--output dir_name] [--format {table,text,chart,all}] [--check-limit] [--user-info path]
 
 오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구
 
@@ -40,6 +40,7 @@ options:
   --format {table,text,chart,all} [{table,text,chart,all} ...]
                         결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart). 옵션:
                         'table', 'text', 'chart', 'all'
+  --grade               차트에 등급 표시
   --use-cache           participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)
   --token TOKEN         API 요청 제한 해제를 위한 깃허브 개인 액세스 토큰
   --check-limit         현재 GitHub API 요청 가능 횟수와 전체 한도를 확인합니다.

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -99,6 +99,11 @@ def parse_arguments() -> argparse.Namespace:
         help = "결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart). 옵션: 'table', 'text', 'chart', 'all'"
     )
     parser.add_argument(
+        "--grade",
+        action="store_true",
+        help="차트에 등급 표시"
+    )
+    parser.add_argument(
         "--use-cache",
         action="store_true",
         help="participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)"
@@ -117,11 +122,6 @@ def parse_arguments() -> argparse.Namespace:
         "--user-info",
         type=str,
         help="사용자 정보 파일의 경로"
-    )
-    parser.add_argument(
-        "--grade",
-        action="store_true",
-        help="차트에 등급(A~F)을 표시"
     )
     return parser.parse_args()
 

--- a/template_README.md
+++ b/template_README.md
@@ -73,3 +73,5 @@ $S = 3P_{fb}^* + 2P_d^* + 2I_{fb}^* + 1I_d^*$
 ## README.md 자동 생성 및 최신 상태 유지 가이드
 👉 [README.md 자동 생성 및 최신 상태 유지 가이드](docs/readme_version_check_guide.md) 문서를 참고 부탁드립니다.
 
+## 차트 생성시 한글 폰트 깨짐 이슈 해결 가이드
+👉 [차트 생성시 한글 폰트 깨짐 이슈 해결 가이드](docs/chart-font-guide.md) 문서를 참고 부탁드립니다.


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/518 에 대한 PR

Specify version (commit id).
https://github.com/oss2025hnu/reposcore-py/commit/8d1c9976338134e8b87b8092852147b191e49dcd

--grade 옵션이 argparse에 추가되었었지만, README에 반영되지 않아 make readme로 갱신하여 반영되도록 수정.