### PR TITLE
[FEAT] 참가자의 PR/이슈 개수 집계 CSV 파일 생성 기능 추가 (#524)

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -280,6 +280,17 @@ class RepoAnalyzer:
 
         df.to_csv(save_path, index=False)
         logging.info(f"📊 CSV 결과 저장 완료: {save_path}")
+        count_csv_path = os.path.join(dir_path or '.', "activity_count.csv")
+        with open(count_csv_path, 'w') as f:
+            f.write("name,feat/bug PR,document PR,typo PR,feat/bug issue,document issue\n")
+            for name, score in scores.items():
+                pr_fb = int(score["feat/bug PR"] / self.score["feat_bug_pr"])
+                pr_doc = int(score["document PR"] / self.score["doc_pr"])
+                pr_typo = int(score["typo PR"] / self.score["typo_pr"])
+                is_fb = int(score["feat/bug issue"] / self.score["feat_bug_is"])
+                is_doc = int(score["document issue"] / self.score["doc_is"])
+                f.write(f"{name},{pr_fb},{pr_doc},{pr_typo},{is_fb},{is_doc}\n")
+        logging.info(f"📄 활동 개수 CSV 저장 완료: {count_csv_path}")
 
     def generate_text(self, scores: Dict, save_path) -> None:
         table = PrettyTable()


### PR DESCRIPTION
## 관련 이슈

[#524](https://github.com/oss2025hnu/reposcore-py/issues/524)



## 변경 내용

- 각 참가자의 활동 내역을 집계하여
name,feat/bug PR,document PR,typo PR,feat/bug issue,document issue
형식의 CSV 파일(activity_count.csv) 을 추가로 생성합니다.
- 기존 점수 기반의 table.csv 와는 별도 파일로 저장됩니다.
- 파일 저장 위치는 동일하게 results/ 디렉토리입니다.
- 로그 출력 시, 두 파일의 생성 완료 메시지를 한 번에 출력하도록 개선하였습니다.



## 테스트
- .venv 환경에서 python main.py -r <user/repo> 실행
- 다음과 같은 로그 출력을 확인:

[📊 CSV 결과 저장 완료: results/table.csv]
[📄 활동 개수 CSV 저장 완료: results/activity_count.csv]
