### PR TITLE
[REFACT] result 디렉토리의 폴더 구조 및 파일명 통일

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -231,20 +231,21 @@ def main():
 
             # 1) CSV 테이블 저장
             if FORMAT_TABLE in formats:
-                table_path = os.path.join(repo_output_dir, "score_participation.csv")
+                table_path = os.path.join(repo_output_dir, "score.csv")
                 repo_aggregator.generate_table(repo_scores, save_path=table_path)
                 logging.info(f"[개별 저장소] CSV 파일 저장 완료: {table_path}")
 
             # 2) 텍스트 테이블 저장
             if FORMAT_TEXT in formats:
-                txt_path = os.path.join(repo_output_dir, "score_participation.txt")
+                txt_path = os.path.join(repo_output_dir, "score.txt")
                 repo_aggregator.generate_text(repo_scores, txt_path)
                 logging.info(f"[개별 저장소] 텍스트 파일 저장 완료: {txt_path}")
 
             # 3) 차트 이미지 저장
             if FORMAT_CHART in formats:
-                chart_path = os.path.join(repo_output_dir, "chart_participation.png")
-                repo_aggregator.generate_chart(repo_scores, save_path=chart_path)
+                chart_filename = "chart_participation_grade.png" if args.grade else "chart_participation.png"
+                chart_path = os.path.join(repo_output_dir, chart_filename)
+                repo_aggregator.generate_chart(repo_scores, save_path=chart_path, show_grade=args.grade)
                 logging.info(f"[개별 저장소] 차트 이미지 저장 완료: {chart_path}")
 
         except Exception as e:
@@ -269,13 +270,13 @@ def main():
 
         # 통합 CSV
         if FORMAT_TABLE in formats:
-            table_path = os.path.join(args.output, "score_participation.csv")
+            table_path = os.path.join(args.output, "score.csv")
             aggregator.generate_table(scores, save_path=table_path)
             logging.info(f"\n[통합] CSV 저장 완료: {table_path}")
 
         # 통합 텍스트
         if FORMAT_TEXT in formats:
-            txt_path = os.path.join(args.output, "score_participation.txt")
+            txt_path = os.path.join(args.output, "score.txt")
             aggregator.generate_text(scores, txt_path)
             logging.info(f"\n[통합] 텍스트 저장 완료: {txt_path}")
 

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -231,13 +231,13 @@ def main():
 
             # 1) CSV 테이블 저장
             if FORMAT_TABLE in formats:
-                table_path = os.path.join(repo_output_dir, "table.csv")
+                table_path = os.path.join(repo_output_dir, "score_participation.csv")
                 repo_aggregator.generate_table(repo_scores, save_path=table_path)
                 logging.info(f"[개별 저장소] CSV 파일 저장 완료: {table_path}")
 
             # 2) 텍스트 테이블 저장
             if FORMAT_TEXT in formats:
-                txt_path = os.path.join(repo_output_dir, "table.txt")
+                txt_path = os.path.join(repo_output_dir, "score_participation.txt")
                 repo_aggregator.generate_text(repo_scores, txt_path)
                 logging.info(f"[개별 저장소] 텍스트 파일 저장 완료: {txt_path}")
 
@@ -269,13 +269,13 @@ def main():
 
         # 통합 CSV
         if FORMAT_TABLE in formats:
-            table_path = os.path.join(args.output, "table.csv")
+            table_path = os.path.join(args.output, "score_participation.csv")
             aggregator.generate_table(scores, save_path=table_path)
             logging.info(f"\n[통합] CSV 저장 완료: {table_path}")
 
         # 통합 텍스트
         if FORMAT_TEXT in formats:
-            txt_path = os.path.join(args.output, "table.txt")
+            txt_path = os.path.join(args.output, "score_participation.txt")
             aggregator.generate_text(scores, txt_path)
             logging.info(f"\n[통합] 텍스트 저장 완료: {txt_path}")
 

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -280,7 +280,7 @@ class RepoAnalyzer:
 
         df.to_csv(save_path, index=False)
         logging.info(f"📊 CSV 결과 저장 완료: {save_path}")
-        count_csv_path = os.path.join(dir_path or '.', "count_participation.csv")
+        count_csv_path = os.path.join(dir_path or '.', "count.csv")
         with open(count_csv_path, 'w') as f:
             f.write("name,feat/bug PR,document PR,typo PR,feat/bug issue,document issue\n")
             for name, score in scores.items():
@@ -364,7 +364,7 @@ class RepoAnalyzer:
 
         # 동적 색상 매핑
         norm = plt.Normalize(min(scores_sorted or [0]), max(scores_sorted or [1]))
-        colormap = cm.get_cmap('viridis')
+        colormap = plt.colormaps['viridis']
         for bar, score in zip(bars, scores_sorted):
             bar.set_color(colormap(norm(score)))
 
@@ -404,10 +404,7 @@ class RepoAnalyzer:
         if save_dir and not os.path.exists(save_dir):
             os.makedirs(save_dir, exist_ok=True)
 
-        chart_filename = "chart_participation_grade.png" if show_grade else "chart_participation.png"
-        chart_path = os.path.join(save_path, chart_filename)
-        
         plt.tight_layout(pad=2)
-        plt.savefig(chart_path)
-        logging.info(f"📈 차트 저장 완료: {chart_path}")
+        plt.savefig(save_path)
+        logging.info(f"📈 차트 저장 완료: {save_path}")
         plt.close()

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -71,7 +71,7 @@ class RepoAnalyzer:
         self._data_collected = True  # 기본값을 True로 설정
 
         self.SESSION = requests.Session()
-        self.SESSION.headers.update({'Authorization': token}) if token else None
+        self.SESSION.headers.update({'Authorization': f'Bearer {token}'}) if token else None
 
     def collect_PRs_and_issues(self) -> None:
         """
@@ -280,7 +280,7 @@ class RepoAnalyzer:
 
         df.to_csv(save_path, index=False)
         logging.info(f"📊 CSV 결과 저장 완료: {save_path}")
-        count_csv_path = os.path.join(dir_path or '.', "activity_count.csv")
+        count_csv_path = os.path.join(dir_path or '.', "count_participation.csv")
         with open(count_csv_path, 'w') as f:
             f.write("name,feat/bug PR,document PR,typo PR,feat/bug issue,document issue\n")
             for name, score in scores.items():
@@ -334,7 +334,7 @@ class RepoAnalyzer:
             txt_file.write(str(table))
         logging.info(f"📝 텍스트 결과 저장 완료: {save_path}")
 
-    def generate_chart(self, scores: Dict, save_path: str = "results", show_grade: bool = False) -> None:
+    def generate_chart(self, scores: Dict, save_path: str, show_grade: bool = False) -> None:
         # 폰트 설정 변경
         plt.rcParams['font.family'] = ['NanumGothic', 'DejaVu Sans']
         
@@ -399,18 +399,14 @@ class RepoAnalyzer:
                 fontsize=9
             )
 
-        if save_path and not os.path.exists(save_path):
-            os.makedirs(save_path, exist_ok=True)
+        # 디렉토리가 없으면 생성
+        save_dir = os.path.dirname(save_path)
+        if save_dir and not os.path.exists(save_dir):
+            os.makedirs(save_dir, exist_ok=True)
 
         chart_filename = "chart_participation_grade.png" if show_grade else "chart_participation.png"
         chart_path = os.path.join(save_path, chart_filename)
-
-        # 기존 파일 삭제
-        if os.path.exists("results/chart_participation.png"):
-            os.remove("results/chart_participation.png")
-        if os.path.exists("results/chart_participation_grade.png"):
-            os.remove("results/chart_participation_grade.png")
-
+        
         plt.tight_layout(pad=2)
         plt.savefig(chart_path)
         logging.info(f"📈 차트 저장 완료: {chart_path}")


### PR DESCRIPTION
## 관련 이슈  

https://github.com/oss2025hnu/reposcore-py/issues/531

---

## 변경 사항 요약  
`results` 디렉토리 내 **출력 파일 구조와 이름을 통일**하고,  
**직관적이지 않은 파일명과 구조**를 리팩토링했습니다.

### 주요 변경 사항
- `table.csv` → `score_participation.csv`로 명확하게 변경
- `table.txt` → `score_participation.txt`로 명확하게 변경
- `activity_count.csv` → `count_participation.csv`로 명확하게 변경
- 차트 이미지는 별도 디렉토리 없이 `results/chart_participation.png`로 통일

---
## 기대 효과
- 결과 파일명만 보고도 **각 파일의 용도 파악이 쉬워짐**
- `results` 디렉토리 내부가 **일관성 있고 직관적인 구조**로 정리됨
- 기여자 및 사용자들이 파일을 **빠르게 찾고 분석** 가능해짐

---

## 기타
- 기존 파일 생성 로직은 그대로 유지하며, 파일명 및 위치만 수정하였습니다.
- 추후 추가되는 결과 파일도 이 naming rule을 따라가면 유지보수가 쉬워집니다.