### PR TITLE
Makefile에 폰트 관련 target을 추가함

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ requirements: venv
 test: requirements
 	$(PYTEST) tests
 
+update-fonts: requirements
+	@echo "Updating fonts cache..."
+	sudo fc-cache -fv
+	$(PYTHON) -c "import shutil; import matplotlib; shutil.rmtree(matplotlib.get_cachedir())"
+
 install-fonts:
 	@echo "Detected distribution: $(DISTRO)"
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PIP := $(VENV)/bin/pip
 PYTEST := $(VENV)/bin/pytest
 
 VERSION := $(shell grep '__version__' reposcore/__init__.py |cut -d'"' -f 2)
+DISTRO := $(shell lsb_release -si)
 
 version:
 	@echo $(VERSION)
@@ -23,6 +24,40 @@ requirements: venv
 
 test: requirements
 	$(PYTEST) tests
+
+install-fonts:
+	@echo "Detected distribution: $(DISTRO)"
+
+ifneq (,$(filter $(DISTRO),Debian Ubuntu))
+	@echo "Installing Noto Sans CJK fonts for Debian..."
+	sudo apt-get update -y
+	sudo apt-get install -y fonts-noto-cjk
+
+else ifneq (,$(filter $(DISTRO),RedHat Fedora RHEL CentOS Rocky))
+	@echo "Installing Noto Sans CJK fonts for RedHat..."
+	sudo dnf install -y google-noto-sans-cjk-fonts
+
+else ifneq (,$(filter $(DISTRO),SUSE openSUSE))
+	@echo "Installing Noto Sans CJK fonts for SUSE..."
+	sudo zypper install -y noto-sans-cjk-fonts
+
+else ifneq (,$(filter $(DISTRO),Arch Manjaro))
+	@echo "Installing Noto Sans CJK fonts for Arch..."
+	sudo pacman -Sy --noconfirm noto-fonts-cjk
+
+else ifneq (,$(filter $(DISTRO),Gentoo))
+	@echo "Installing Noto Sans CJK fonts for Gentoo..."
+	sudo emerge -y media-fonts/noto-cjk
+
+else ifneq (,$(filter $(DISTRO),Alpine))
+	@echo "Installing Noto Sans CJK fonts for Alpine..."
+	sudo apk add --no-cache font-noto-cjk
+
+else
+	@echo "Unsupported distribution: $(DISTRO)"
+	@echo "Please install Noto Sans CJK fonts manually"
+	@exit 1
+endif
 
 # README 동기화
 readme: README.md

--- a/docs/chart-font-guide.md
+++ b/docs/chart-font-guide.md
@@ -3,12 +3,10 @@
 
 ### 패키지 업데이트 및 패키지 설치
 ```bash
-sudo apt update
-sudo apt install fonts-nanum
+make install-fonts
 ```
 
 ### 폰트 목록 업데이트 및 matplotlib 캐시 삭제
 ```bash
-sudo fc-cache -fv
-rm ~/.cache/matplotlib/fontlist-*.json
+make update-fonts
 ```

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from typing import Dict, Optional
+import matplotlib.font_manager as fm
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 
@@ -13,7 +14,6 @@ from .utils.retry_request import retry_request
 import logging
 import sys
 import os
-import matplotlib.font_manager as fm
 
 logging.basicConfig(
     level=logging.INFO,
@@ -336,12 +336,14 @@ class RepoAnalyzer:
         logging.info(f"📝 텍스트 결과 저장 완료: {save_path}")
 
     def generate_chart(self, scores: Dict, save_path: str, show_grade: bool = False) -> None:
-        # 폰트 설정 변경 - 나눔고딕 폰트가 있는지 확인하고 있으면 사용
-        fonts = [f.name for f in fm.fontManager.ttflist]
-        if 'NanumGothic' in fonts:
-            plt.rcParams['font.family'] = ['NanumGothic']
-        else:
-            plt.rcParams['font.family'] = ['DejaVu Sans']  # fallback
+        # Linux 환경에서 CJK 폰트 수동 설정
+        # OSS 한글 폰트인 본고딕, 나눔고딕, 백묵 중 순서대로 하나를 선택
+        for pref_name in ['Noto Sans CJK', 'NanumGothic', 'Baekmuk Dotum']:
+            found_ttf = next((ttf for ttf in fm.fontManager.ttflist if pref_name in ttf.name), None)
+
+            if found_ttf:
+                plt.rcParams['font.family'] = found_ttf.name
+                break
         
         sorted_scores = sorted(
             [(key, value.get('total', 0)) for (key, value) in scores.items()],


### PR DESCRIPTION
#512 

`Makefile`에 이슈에서 제시한 `install-fonts` 및 `update-fonts` target을 추가함.
`reposcore/analyzer.py`에 한글 폰트를 순차적으로 찾는 코드를 추가함.
`docs/chart-font-guide.md` 문서의 설명을 `make`를 사용하도록 변경함.