### PR TITLE
[FEAT] 로그 메시지에 로그 레벨을 함께 출력하는 기능 추가에 대한 PR입니다.

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -23,7 +23,7 @@ VALID_FORMATS_DISPLAY = ", ".join(VALID_FORMATS)
 logging.basicConfig(
     stream=sys.stdout,
     level=logging.INFO,
-    format='[%(asctime)s] %(message)s',
+    format='[%(asctime)s] [%(levelname)s] %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -16,7 +16,7 @@ import os
 
 logging.basicConfig(
     level=logging.INFO,
-    format='[%(asctime)s] %(message)s',
+    format='[%(asctime)s] [%(levelname)s] %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 


### PR DESCRIPTION
#534 [FEAT] 로그 메시지에 로그 레벨을 함께 출력하는 기능 추가

**Specify version (commit id).**
https://github.com/oss2025hnu/reposcore-py/commit/8796e891a7b4e7a6ce04b997ebdfd3cc206e2005

**변경 내용**
로그 메시지에 로그 레벨을 함께 출력하는 기능 추가