### PR TITLE
[REFACTOR] --output 지정 디렉토리 path오류 리팩토링

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -282,8 +282,9 @@ def main():
 
         # 통합 차트
         if FORMAT_CHART in formats:
-            aggregator.generate_chart(scores, save_path=args.output, show_grade=args.grade)
-            chart_path = os.path.join(args.output, "chart_participation.png")
+            chart_filename = "chart_participation_grade.png" if args.grade else "chart_participation.png"
+            chart_path = os.path.join(args.output, chart_filename)
+            aggregator.generate_chart(scores, save_path=chart_path, show_grade=args.grade)
             logging.info(f"\n[통합] 차트 이미지 저장 완료: {chart_path}")
 
     except Exception as e:


### PR DESCRIPTION
#531

결과물이 result폴더(디폴트값) 혹은 --output 인자를 통해 폴더를 지정했을 경우, chart.png 파일이 바깥으로 튀지 않도록 고쳤습니다.