### PR TITLE
테마 매니저 기능 구현 및 CLI --theme 옵션 추가

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -138,6 +138,12 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         help="사용자 정보 파일의 경로"
     )
+    parser.add_argument(
+        "--theme", "-t",
+        choices=["default", "dark"],
+        default="default",
+        help="테마 선택 (default 또는 dark)"
+    )
     return parser.parse_args()
 
 def merge_participants(overall: dict, new_data: dict) -> dict:
@@ -187,7 +193,7 @@ def main():
     for repo in final_repositories:
         logging.info(f"분석 시작: {repo}")
 
-        analyzer = RepoAnalyzer(repo, token=github_token)
+        analyzer = RepoAnalyzer(repo, token=github_token, theme=args.theme)
         # 저장소별 캐시 파일 생성 (예: cache_oss2025hnu_reposcore-py.json)
         cache_file_name = f"cache_{repo.replace('/', '_')}.json"
         cache_path = os.path.join(args.output, cache_file_name)
@@ -213,7 +219,7 @@ def main():
                 if args.user_info and os.path.exists(args.user_info) else None
 
             # 저장소별 aggregator 인스턴스 생성
-            repo_aggregator = RepoAnalyzer(repo, token=github_token)
+            repo_aggregator = RepoAnalyzer(repo, token=github_token, theme=args.theme)
             repo_aggregator.participants = analyzer.participants
 
             # 스코어 계산
@@ -254,7 +260,7 @@ def main():
         overall_participants = merge_participants(overall_participants, analyzer.participants)
         logging.info(f"분석 완료: {repo}")
     # 병합된 데이터를 가지고 통합 분석을 진행합니다.
-    aggregator = RepoAnalyzer("multiple_repos", token=github_token)
+    aggregator = RepoAnalyzer("multiple_repos", token=github_token, theme=args.theme)
     aggregator.participants = overall_participants
 
     try:
@@ -282,8 +288,10 @@ def main():
 
         # 통합 차트
         if FORMAT_CHART in formats:
-            aggregator.generate_chart(scores, save_path=args.output, show_grade=args.grade)
-            chart_path = os.path.join(args.output, "chart_participation.png")
+            # 수정된 코드
+            chart_filename = "chart_participation_grade.png" if args.grade else "chart_participation.png"
+            chart_path = os.path.join(args.output, chart_filename)
+            aggregator.generate_chart(scores, save_path=chart_path, show_grade=args.grade)
             logging.info(f"\n[통합] 차트 이미지 저장 완료: {chart_path}")
 
     except Exception as e:

--- a/reposcore/utils/theme_manager.py
+++ b/reposcore/utils/theme_manager.py
@@ -1,0 +1,68 @@
+class ThemeManager:
+    def __init__(self):
+        self.themes = {}
+        self.current_theme = 'default'
+        self._initialize_default_themes()
+
+    def _initialize_default_themes(self):
+        self.themes['default'] = {
+            'colors': {
+                'primary': '#007bff',
+                'secondary': '#6c757d',
+                'background': '#ffffff',
+                'text': '#212529',
+                'grade_colors': {
+                    'A': '#28a745',
+                    'B': '#17a2b8',
+                    'C': '#ffc107',
+                    'D': '#fd7e14',
+                    'E': '#dc3545',
+                    'F': '#6c757d'
+                }
+            },
+            'table': {
+                'style': {
+                    'header_color': 'yellow',
+                    'border_color': 'grey'
+                }
+            },
+            'chart': {
+                'style': {
+                    'background': '#ffffff',
+                    'text': '#212529',
+                    'grid': '#e9ecef',
+                    'colormap': 'viridis'
+                }
+            }
+        }
+
+        self.themes['dark'] = {
+            'colors': {
+                'primary': '#0d6efd',
+                'secondary': '#6c757d',
+                'background': '#212529',
+                'text': '#f8f9fa',
+                'grade_colors': {
+                    'A': '#2dce89',
+                    'B': '#11cdef',
+                    'C': '#fb6340',
+                    'D': '#f5365c',
+                    'E': '#8965e0',
+                    'F': '#adb5bd'
+                }
+            },
+            'table': {
+                'style': {
+                    'header_color': 'cyan',
+                    'border_color': 'white'
+                }
+            },
+            'chart': {
+                'style': {
+                    'background': '#212529',
+                    'text': '#f8f9fa',
+                    'grid': '#495057',
+                    'colormap': 'plasma'
+                }
+            }
+        }


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/538 에 대한 PR

Specify version (commit id)
https://github.com/oss2025hnu/reposcore-py/commit/8796e891a7b4e7a6ce04b997ebdfd3cc206e2005

## 변경 사항

- `ThemeManager` 클래스 도입 (utils/theme_manager.py)
- `RepoAnalyzer` 클래스에서 테마 적용 가능하도록 `theme` 인자 추가
- `generate_chart`, `generate_text` 함수에 테마 기반 스타일 적용
- CLI 옵션에 `--theme` / `-t` 추가 (선택: `default`, `dark`)
- `default`, `dark` 2가지 기본 테마 제공

---

## 사용 예시
![chart_participation](https://github.com/user-attachments/assets/20c043df-1ebe-4084-883f-a2c85cb36f07)


```bash
python -m reposcore oss2025hnu/reposcore-py --format chart --theme dark
```