### PR TITLE
[BUG] NanumGothic 폰트가 없을 경우 로그가 과도하게 출력되는 문제 수정에 대한 PR

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -13,6 +13,7 @@ from .utils.retry_request import retry_request
 import logging
 import sys
 import os
+import matplotlib.font_manager as fm
 
 logging.basicConfig(
     level=logging.INFO,
@@ -335,8 +336,12 @@ class RepoAnalyzer:
         logging.info(f"📝 텍스트 결과 저장 완료: {save_path}")
 
     def generate_chart(self, scores: Dict, save_path: str, show_grade: bool = False) -> None:
-        # 폰트 설정 변경
-        plt.rcParams['font.family'] = ['NanumGothic', 'DejaVu Sans']
+        # 폰트 설정 변경 - 나눔고딕 폰트가 있는지 확인하고 있으면 사용
+        fonts = [f.name for f in fm.fontManager.ttflist]
+        if 'NanumGothic' in fonts:
+            plt.rcParams['font.family'] = ['NanumGothic']
+        else:
+            plt.rcParams['font.family'] = ['DejaVu Sans']  # fallback
         
         sorted_scores = sorted(
             [(key, value.get('total', 0)) for (key, value) in scores.items()],


### PR DESCRIPTION
## 관련 이슈

https://github.com/oss2025hnu/reposcore-py/issues/544

## 변경 사항
generate_chart 메서드 내 폰트 설정 로직을 개선하여, 'NanumGothic' 폰트가 시스템에 설치되어 있지 않을 경우 'DejaVu Sans' 폰트를 대체로 사용하도록 수정했습니다.
이 변경으로 인해 'NanumGothic' 폰트가 없을 때 발생하는 경고 메시지가 더 이상 출력되지 않으며, 모든 환경에서 일관된 차트 렌더링이 가능합니다.

## 이유
'NanumGothic' 폰트가 설치되어 있지 않은 시스템에서 차트를 생성할 때, 관련 경고 메시지가 과도하게 출력되는 문제가 있었습니다.
이 문제를 해결하기 위해 폰트가 설치되어 있는지 확인한 후, 없으면 대체 폰트를 사용하도록 로직을 개선했습니다.

## 테스트
'NanumGothic' 폰트가 설치된 환경과 설치되지 않은 환경에서 차트를 생성하여, 경고 메시지가 출력되지 않고 차트가 정상적으로 렌더링되는 것을 확인했습니다.
