### PR TITLE
[BUG] 테스트시 발생하는 warning 해결 

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -409,7 +409,7 @@ class RepoAnalyzer:
         if save_dir and not os.path.exists(save_dir):
             os.makedirs(save_dir, exist_ok=True)
 
-        plt.tight_layout(pad=2)
+        plt.subplots_adjust(left=0.25, right=0.98, top=0.93, bottom=0.05)
         plt.savefig(save_path)
         logging.info(f"📈 차트 저장 완료: {save_path}")
         plt.close()


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/460
기존에 사용하던 plt.tight_layout(pad=2) 호출 시 warning이 발생하여
이를 해결하기 위해 constrained_layout=True 옵션을 사용해보았습니다.

하지만 이 경우에도 axes sizes collapsed to zero 경고가 추가로 발생하였습니다.

따라서 위 warning은 수평막대그래프의 구조적 한계로 보입니다. 특히 Y축에 69명의 참여자 이름을 전부 나열해야하는 상황에서는 matplotlib이 레이아웃 계산을 정상적으로 수행하지 것으로 판단됩니다.

따라서 기존에 자동으로 레이아웃을 적용하는 tight_layout 은 어차피 제 기능을 발휘하지 못하므로 제거하였습니다. 
여백을 수동으로 조정하는 방식으로 변경해주었습니다.