### PR TITLE
[BUG] 잘못된 토큰을 입력해도 정상적으로 작동에 대한 PR입니다.

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -151,6 +151,15 @@ def merge_participants(overall: dict, new_data: dict) -> dict:
                 overall[user][key] = overall[user].get(key, 0) + value
     return overall
 
+def validate_token(github_token: str):
+    headers = {}
+    if github_token:
+        headers["Authorization"] = f"token {github_token}"
+    response = requests.get("https://api.github.com/user", headers=headers)
+    if response.status_code != 200:
+        logging.error('❌ 인증 실패: 잘못된 GitHub 토큰입니다. 토큰 값을 확인해 주세요.')
+        sys.exit(1)
+
 def main():
     """Main execution function"""
     args = parse_arguments()
@@ -159,6 +168,9 @@ def main():
         github_token = os.getenv('GITHUB_TOKEN')
     elif args.token == '-':
         github_token = sys.stdin.readline().strip()
+
+    if github_token and len(github_token) != 0:
+        validate_token(github_token)
 
     # --check-limit 옵션 처리: 이 옵션이 있으면 repository 인자 없이 실행됨.
     if args.check_limit:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,6 +33,16 @@ def test_main_without_repo_option():
     assert result.returncode != 0
     assert "'owner/repo' 형식으로" in result.stdout or "required" in result.stderr
 
+def test_main_invalid_token():
+    """repo 옵션 없이 실행했을 때 에러 출력 확인"""
+    result = subprocess.run(
+        [sys.executable, "-m", "reposcore", "--token", "invalid_token", "oss2025hnu/reposcore-py"],
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode != 0
+    assert "❌ 인증 실패: 잘못된 GitHub 토큰입니다. 토큰 값을 확인해 주세요." in result.stderr 
+
 # def test_main_invalid_repo_format():
 #     """잘못된 형식의 repo 인자에 대한 처리"""
 #     result = subprocess.run(


### PR DESCRIPTION
#502 [BUG] 잘못된 토큰을 입력해도 정상적으로 작동

**Version**
https://github.com/oss2025hnu/reposcore-py/commit/1c159711a4db7b56fb2da9c5aa8aac38e99bc61a

**변경 사항***
못된 토큰을 입력시 `❌ 인증 실패: 잘못된 GitHub 토큰입니다. 토큰 값을 확인해 주세요.` 오류 메시지 출력 후 종료

