### PR TITLE
[REFACTOR] analyzer.py 중복 오류 처리 수정

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -74,6 +74,17 @@ class RepoAnalyzer:
         self.SESSION = requests.Session()
         self.SESSION.headers.update({'Authorization': f'Bearer {token}'}) if token else None
 
+    def _handle_api_error(self, status_code: int) -> bool:
+        if status_code in ERROR_MESSAGES:
+            logging.error(ERROR_MESSAGES[status_code])
+            self._data_collected = False
+            return True
+        elif status_code != 200:
+            logging.warning(f"⚠️ GitHub API 요청 실패: {status_code}")
+            self._data_collected = False
+            return True
+        return False
+
     def collect_PRs_and_issues(self) -> None:
         """
         하나의 API 호출로 GitHub 이슈 목록을 가져오고,
@@ -95,41 +106,10 @@ class RepoAnalyzer:
                                         'per_page': per_page,
                                         'page': page
                                     })
-            status_code = response.status_code
-            if status_code == 401:
-                message = ERROR_MESSAGES[status_code]
-                logging.error(message)
-                self._data_collected = False
-                return
-            elif status_code == 403:
-                message = ERROR_MESSAGES[status_code]
-                logging.error(message)
-                self._data_collected = False
-                return
-            elif status_code == 404:
-                message = ERROR_MESSAGES[status_code]
-                logging.error(message)
-                self._data_collected = False
-                return
-            elif status_code == 500:
-                message = ERROR_MESSAGES[status_code]
-                logging.error(message)
-                self._data_collected = False
-                return
-            elif status_code == 503:
-                message = ERROR_MESSAGES[status_code]
-                logging.error(message)
-                self._data_collected = False
-                return
-            elif status_code == 422:
-                message = ERROR_MESSAGES[status_code]
-                logging.error(message)
-                self._data_collected = False
-                return
-            elif status_code != 200:
-                logging.warning(f"⚠️ GitHub API 요청 실패: {response.status_code}")
-                self._data_collected = False
-                return
+           
+             # 🔽 에러 처리 부분 25줄 → 3줄로 리팩토링
+            if self._handle_api_error(response.status_code):
+            return
 
             items = response.json()
             if not items:

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -109,7 +109,7 @@ class RepoAnalyzer:
            
              # 🔽 에러 처리 부분 25줄 → 3줄로 리팩토링
             if self._handle_api_error(response.status_code):
-            return
+                return
 
             items = response.json()
             if not items:


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-py/issues/539


현재 `collect_PRs_and_issues` 메서드에서 GitHub API 에러 처리 코드가 중복되어 있어 코드의 가독성과 유지보수성이 떨어집니다. 각 상태 코드(401, 403, 404 등)마다 거의 동일한 에러 처리 로직이 반복되어 있어 헬퍼 메서드로 분리하여 코드 중복을 제거하여 가독성을 향상 시켰습니다. 

7985798ad0bdb17a94cb9c3a4c8bf16331bd4792
`self._handle_api_error`를 추가하여 코드를 더욱 간략하게 수정하였습니다.