### PR TITLE
들여쓰기 수정

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -87,7 +87,7 @@ class RepoAnalyzer:
     # 사용자 제외 목록
     EXCLUDED_USERS = {"kyahnu", "kyagrd"}
 
-   def __init__(self, repo_path: str, token: Optional[str] = None, theme: str = 'default'):
+    def __init__(self, repo_path: str, token: Optional[str] = None, theme: str = 'default'):
         if not check_github_repo_exists(repo_path):
             logging.error(f"입력한 저장소 '{repo_path}'가 GitHub에 존재하지 않습니다.")
             sys.exit(1)


### PR DESCRIPTION
## Specific Version
https://github.com/oss2025hnu/reposcore-py/commit/eb69211ad681463138a218185e7755bdc2bee230

## 변경 내용
```python
def __init__(self, repo_path: str, token: Optional[str] = None, theme: str = 'default'):
```
- def 선언 앞에 스페이스 3칸만 존재하여 IndentationError 발생
- Python에서는 클래스 내부 메서드는 스페이스 4칸으로 들여쓰기 해야 하므로 이를 반영하여 수정
