### PR TITLE
[FEAT] check_github_repo_exists 유틸 함수로 분리 및 bypass 처리 추가

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -9,6 +9,7 @@ from typing import Optional, List
 from datetime import datetime
 import json
 import logging
+from .utils.github_utils import check_github_repo_exists
 
 # 포맷 상수
 FORMAT_TABLE = "table"
@@ -194,8 +195,9 @@ def main():
         if not validate_repo_format(repo):
             logging.error(f"오류: 저장소 '{repo}'는 'owner/repo' 형식으로 입력해야 합니다. 예) 'oss2025hnu/reposcore-py'")
             sys.exit(1)
-        if not check_github_repo_exists(repo):
+        if not check_github_repo_exists(repo, bypass=False):
             logging.warning(f"입력한 저장소 '{repo}'가 깃허브에 존재하지 않을 수 있음.")
+            sys.exit(1)
 
     logging.info(f"저장소 분석 시작: {', '.join(final_repositories)}")
 

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -47,16 +47,6 @@ def validate_repo_format(repo: str) -> bool:
     parts = repo.split("/")
     return len(parts) == 2 and all(parts)
 
-def check_github_repo_exists(repo: str) -> bool:
-    """Check if the given GitHub repository exists"""
-    url = f"https://api.github.com/repos/{repo}"
-    response = requests.get(url)
-    if response.status_code == 403:
-        logging.warning("⚠️ GitHub API 요청 실패: 403 (비인증 상태로 요청 횟수 초과일 수 있습니다.)")
-        logging.info("ℹ️ 해결 방법: --token 옵션으로 GitHub Access Token을 전달해보세요.")
-        return False
-    return response.status_code == 200
-
 def check_rate_limit(token: Optional[str] = None) -> None:
     """현재 GitHub API 요청 가능 횟수와 전체 한도를 확인하고 출력하는 함수"""
     headers = {}

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -17,6 +17,8 @@ import logging
 import sys
 import os
 
+from .utils.github_utils import check_github_repo_exists
+
 logging.basicConfig(
     level=logging.INFO,
     format='[%(asctime)s] [%(levelname)s] %(message)s',
@@ -34,24 +36,6 @@ ERROR_MESSAGES = {
     422: ("⚠️ 요청 실패 (422): 처리할 수 없는 컨텐츠\n"
             "⚠️ 유효성 검사에 실패 했거나, 엔드 포인트가 스팸 처리되었습니다.")
 }
-
-def check_github_repo_exists(repo: str) -> bool:
-    return True  # 지금 여러 개의 저장소를 입력하는 경우 문제를 일으키기 때문에 무조건 True로 바꿔놓음
-
-
-#    """주어진 GitHub 저장소가 존재하는지 확인하는 함수"""
-#    url = f"https://api.github.com/repos/{repo}"
-#    response = requests.get(url)
-#    
-#    if response.status_code == 403:
-#        logging.warning("⚠️ GitHub API 요청 실패: 403 (비인증 상태로 요청 횟수 초과일 수 있습니다.)")
-#        logging.info("ℹ️ 해결 방법: --token 옵션으로 GitHub Access Token을 전달해보세요.")
-#    elif response.status_code == 404:
-#        logging.warning(f"⚠️ 저장소 '{repo}'가 존재하지 않습니다.")
-#    elif response.status_code != 200:
-#        logging.warning(f"⚠️ 요청 실패: {response.status_code}")
-#
-#    return response.status_code == 200
 
 class RepoAnalyzer:
     """Class to analyze repository participation for scoring"""
@@ -88,7 +72,7 @@ class RepoAnalyzer:
     EXCLUDED_USERS = {"kyahnu", "kyagrd"}
 
     def __init__(self, repo_path: str, token: Optional[str] = None, theme: str = 'default'):
-        if not check_github_repo_exists(repo_path):
+        if not check_github_repo_exists(repo_path, bypass=True): #테스트 중이므로 무조건 True 반환
             logging.error(f"입력한 저장소 '{repo_path}'가 GitHub에 존재하지 않습니다.")
             sys.exit(1)
 

--- a/reposcore/utils/github_utils.py
+++ b/reposcore/utils/github_utils.py
@@ -1,0 +1,28 @@
+import requests
+import logging
+
+def check_github_repo_exists(repo: str, bypass: bool = False) -> bool:
+    """
+    GitHub 저장소 존재 여부를 확인하는 함수.
+
+    - bypass=True인 경우: 무조건 True 반환 (테스트용).
+    - bypass=False인 경우: 실제 GitHub API로 확인.
+    """
+    if bypass:
+        logging.warning("⚠️ [TEST MODE] check_github_repo_exists()는 항상 True를 반환합니다. 실제 검사는 수행되지 않습니다.")
+        return True
+
+    url = f"https://api.github.com/repos/{repo}"
+    response = requests.get(url)
+
+    if response.status_code == 200:
+        return True
+    elif response.status_code == 403:
+        logging.warning("⚠️ GitHub API 요청 실패: 403 (요청 횟수 초과 또는 인증 오류)")
+        logging.info("ℹ️ 해결 방법: --token 옵션 또는 GITHUB_TOKEN 환경 변수 사용")
+    elif response.status_code == 404:
+        logging.warning(f"⚠️ 저장소 '{repo}'가 존재하지 않습니다.")
+    else:
+        logging.warning(f"⚠️ 요청 실패: HTTP 상태 코드 {response.status_code}")
+
+    return False


### PR DESCRIPTION
## Issue ID 
[FEAT] check_github_repo_exists() 중복 정의 제거 #468

## Specific Version
04b6156
a05a317

## 변경 내용
- check_github_repo_exists() 함수를 utils/github_utils.py로 분리
- bypass 옵션을 추가해 테스트용(True), 실제검사용(False)으로 구분
- __main__.py는 실제 검사, analyzer.py는 테스트 우회
- analyzer의 더미 함수 제거 및 중복 정의 해소
