### PR TITLE
[FEAT] 차트에 직관적인 등수 포맷 및 이름 앞 순위 표기 기능 추가에 대한 PR (#549)

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -461,8 +461,25 @@ class RepoAnalyzer:
                 ranks.append(ranks[-1])
             current_rank += 1
 
+        # 등수를 영어 서수로 변환하는 함수
+        def get_ordinal_suffix(rank):
+            if rank == 1:
+                return "1st"
+            elif rank == 2:
+                return "2nd"
+            elif rank == 3:
+                return "3rd"
+            else:
+                return f"{rank}th"
+
+        # 사용자 이름에 등수 추가
+        ranked_participants = []
+        for i, participant in enumerate(participants):
+            rank_suffix = get_ordinal_suffix(ranks[i])
+            ranked_participants.append(f"{rank_suffix} {participant}")
+
         plt.figure(figsize=(self.CHART_CONFIG['figure_width'], height))
-        bars = plt.barh(participants, scores_sorted, height=self.CHART_CONFIG['bar_height'])
+        bars = plt.barh(ranked_participants, scores_sorted, height=self.CHART_CONFIG['bar_height'])
 
         # 색상 매핑 (기본 colormap 또는 등급별 색상)
         if show_grade:
@@ -509,8 +526,8 @@ class RepoAnalyzer:
                         break
                 grade = f" ({grade_assigned})"
 
-            # 점수, 등급, 순위 표시
-            score_text = f'{int(score)}{grade} ({ranks[i]}위)'
+            # 점수와 등급만 표시 (순위는 이름 앞에 표시되므로 제거)
+            score_text = f'{int(score)}{grade}'
             
             # 활동 비율 표시 (앞글자만 사용)
             ratio_text = f'F/B: {feat_bug_ratio:.1f}% D: {doc_ratio:.1f}% T: {typo_ratio:.1f}%'


### PR DESCRIPTION
## Issue ID 

https://github.com/oss2025hnu/reposcore-py/issues/549

## Specific Version

3bdc04d56acb80f5c34861f372aede5507d46596

## 변경 내용
`generate_chart` 메서드에서 사용자 이름 앞에 등수를 영어 서수 형식으로 추가했습니다.
 "1st joon0447", "2nd Jae-Hyuk-Lee"와 같은 형식으로 표시됩니다.
등수는 1등부터 3등까지는 각각 "1st", "2nd", "3rd"로 표시되며, 4등부터는 "4th", "5th"와 같은 형식으로 표시됩니다.
차트의 막대에 표시되는 텍스트에서 등수는 제거되고, 점수와 등급만 표시됩니다.
차트의 가독성이 향상되어 사용자가 자신의 순위를 더 쉽게 파악할 수 있도록 개선하였습니다.

차트 스크린샷을 함께 첨부하겠습니다.
<img width="544" alt="스크린샷 2025-04-22 오전 5 17 27" src="https://github.com/user-attachments/assets/c08a765c-4a52-4f88-883b-878b025ba4f9" />
