### PR TITLE
[REFACTOR] count.csv의 생성을 generate_table()에서 분리에 대한 PR (#546)

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -261,6 +261,7 @@ def main():
             if FORMAT_TABLE in formats:
                 table_path = os.path.join(repo_output_dir, "score.csv")
                 repo_aggregator.generate_table(repo_scores, save_path=table_path)
+                repo_aggregator.generate_count_csv(repo_scores, save_path=table_path)
                 logging.info(f"[개별 저장소] CSV 파일 저장 완료: {table_path}")
 
             # 2) 텍스트 테이블 저장
@@ -303,6 +304,7 @@ def main():
         if FORMAT_TABLE in formats:
             table_path = os.path.join(args.output, "score.csv")
             aggregator.generate_table(scores, save_path=table_path)
+            aggregator.generate_count_csv(scores, save_path=table_path)
             logging.info(f"\n[통합] CSV 저장 완료: {table_path}")
 
         # 통합 텍스트

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -114,22 +114,22 @@ def test_generate_table_creates_file():
     analyzer = RepoAnalyzer("dummy/repo")
     scores = {
         "alice": {
-            "p_enhancement": 3,
-            "p_bug": 0,
-            "p_typo": 1,
-            "p_documentation": 3,
-            "i_enhancement": 3,
-            "i_bug": 0,
-            "i_documentation": 3,
+            "feat/bug PR": 9,
+            "document PR": 6,
+            "typo PR": 1,
+            "feat/bug issue": 6,
+            "document issue": 3,
+            "total": 25,
+            "rate": 100
         },
         "bob": {
-            "p_enhancement": 3,
-            "p_bug": 0,
-            "p_typo": 0,
-            "p_documentation": 3,
-            "i_enhancement": 3,
-            "i_bug": 0,
-            "i_documentation": 3,
+            "feat/bug PR": 9,
+            "document PR": 6,
+            "typo PR": 0,
+            "feat/bug issue": 6,
+            "document issue": 3,
+            "total": 24,
+            "rate": 96
         }
     }
 
@@ -137,28 +137,65 @@ def test_generate_table_creates_file():
         filepath = os.path.join(tmpdir, "test_table.csv")
         analyzer.generate_table(scores, save_path=filepath)
         assert os.path.isfile(filepath), "CSV 파일이 생성되지 않았습니다."
+        # count.csv는 더 이상 generate_table에서 생성하지 않음
+        count_path = os.path.join(os.path.dirname(filepath), "count.csv")
+        assert not os.path.isfile(count_path), "count.csv 파일이 generate_table에서 생성되었습니다."
 
+def test_generate_count_csv_creates_file():
+    analyzer = RepoAnalyzer("dummy/repo")
+    scores = {
+        "alice": {
+            "feat/bug PR": 9,
+            "document PR": 6,
+            "typo PR": 1,
+            "feat/bug issue": 6,
+            "document issue": 3,
+            "total": 25,
+            "rate": 100
+        },
+        "bob": {
+            "feat/bug PR": 9,
+            "document PR": 6,
+            "typo PR": 0,
+            "feat/bug issue": 6,
+            "document issue": 3,
+            "total": 24,
+            "rate": 96
+        }
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = os.path.join(tmpdir, "test_scores.csv")
+        count_path = analyzer.generate_count_csv(scores, save_path=filepath)
+        assert os.path.isfile(count_path), "count.csv 파일이 생성되지 않았습니다."
+        
+        # 생성된 파일 내용 확인
+        with open(count_path, 'r') as f:
+            content = f.read()
+            assert "name,feat/bug PR,document PR,typo PR,feat/bug issue,document issue" in content
+            assert "alice,3,3,1,3,3" in content
+            assert "bob,3,3,0,3,3" in content
 
 def test_generate_chart_creates_file():
     analyzer = RepoAnalyzer("dummy/repo")
     scores = {
         "alice": {
-            "p_enhancement": 3,
-            "p_bug": 0,
-            "p_typo": 0,
-            "p_documentation": 3,
-            "i_enhancement": 3,
-            "i_bug": 0,
-            "i_documentation": 3,
+            "feat/bug PR": 9,
+            "document PR": 6,
+            "typo PR": 0,
+            "feat/bug issue": 6,
+            "document issue": 3,
+            "total": 24,
+            "rate": 100
         },
         "bob": {
-            "p_enhancement": 3,
-            "p_bug": 0,
-            "p_typo": 0,
-            "p_documentation": 3,
-            "i_enhancement": 3,
-            "i_bug": 0,
-            "i_documentation": 3,
+            "feat/bug PR": 9,
+            "document PR": 6,
+            "typo PR": 0,
+            "feat/bug issue": 6,
+            "document issue": 3,
+            "total": 24,
+            "rate": 100
         }
     }
 


### PR DESCRIPTION
## Issue ID 

https://github.com/oss2025hnu/reposcore-py/issues/546

## Specific Version

c8828e7c66de97e67235014f03cf2564de3c905a

## 변경 내용
generate_table() 함수에서 점수 테이블(score.csv)과 카운트 테이블(count.csv) 생성이라는 두 가지 책임을 분리했습니다.
새로운 generate_count_csv() 함수를 만들어 활동 개수 기반 CSV 파일 생성을 담당하게 했습니다.

generate_count_csv() 함수는 파일 경로를 반환하도록 설계하여 main에서 모든 csv 생성 로직을 호출하도록 설계를 일관화했습니다.

새로운 test_generate_count_csv_creates_file() 테스트를 추가하여 count.csv가 올바르게 생성되는지 확인하였습니다.

## 테스트 방법

아래 명령어를 터미널에서 실행합니다.

``` 
pytest tests/test_analyzer.py -k test_generate_count_csv_creates_file 
```
해당 로직에 대한 테스트가 올바르게 통과되는 것을 확인하였습니다.

<img width="586" alt="스크린샷 2025-04-22 오후 7 38 35" src="https://github.com/user-attachments/assets/c354abb9-a36a-4cd4-a51e-19386af29f68" />

