### PR TITLE
[DOC] README.md 생성 명령을 ci.yaml에 넣어서 깃헙 액션 자동화에 대한 pr 입니다

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Python CI
+name: Python CI and README Sync
 
 on:
   push:
@@ -10,28 +10,68 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 리포지토리 체크아웃
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Python 환경 설정
+      # Python 환경 설정
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: 의존성 설치
+      # 의존성 설치
+      - name: Install dependencies
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      - name: pytest를 사용한 테스트 실행
+
+      # pytest를 사용한 테스트 실행
+      - name: Run tests with pytest
         run: |
           pytest tests --verbose --junitxml=test-results.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      # Push, Pull request시 테스트를 시행하고 결과를 test-results.xml로 생성함
+
+      # 테스트 결과 업로드
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results.xml
+
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Python 환경 설정
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'  # 원하는 Python 버전 (3.x 추천)
+
+      # 의존성 설치
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      # README.md 파일을 자동으로 생성하는 스크립트 실행
+      - name: Generate README.md
+        run: |
+          python generate_readme.py  # 실제 구현에 맞는 스크립트 사용
+
+      # 변경된 README.md 파일을 커밋하고 푸시
+      - name: Commit updated README.md
+        run: |
+          git config --global user.name "Your GitHub Username"
+          git config --global user.email "your-email@example.com"
+          git add README.md
+          git commit -m "Update README.md automatically"
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GitHub token 사용


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/586

## Specific Version
18adc67dedd28a42b59acb22e1fdc0c30b36c47a

## 변경 내용
README.md 자동 업데이트 기능 추가:

새로운 update-readme 잡을 추가하여, 코드 변경 시 자동으로 README.md 파일을 갱신하는 기능을 구현했습니다.

generate_readme.py 스크립트를 사용하여 README.md 파일을 자동으로 생성하도록 설정했습니다.

업데이트된 README.md 파일은 자동으로 커밋되고 푸시됩니다.

기존 Python CI 잡 유지:

기존의 pytest를 사용한 테스트 실행 부분은 그대로 유지되었습니다.

테스트 결과는 test-results.xml 파일로 생성되며, 이를 GitHub Actions의 아티팩트로 업로드합니다.

독립적인 두 잡(test와 update-readme) 구성:

test 잡은 기존대로 테스트를 실행하며, update-readme 잡은 README.md 파일을 자동으로 갱신하는 기능만 수행합니다.

이 두 잡은 서로 독립적으로 실행되며, 코드 변경 시 README.md 파일이 자동으로 최신 상태로 유지됩니다.

README.md 갱신과 테스트가 별도의 작업으로 실행:

이제 README.md 파일 갱신과 테스트는 서로 독립적으로 실행되어, 코드 변경에 따른 문서화 작업이 자동화되었습니다.
