### PR TITLE
Codespace 환경에서 autoDocstring 확장을 자동 설치하도록 devcontainer 설정 추가

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,29 @@
 {
-    "name": "Python RepoScore DevContainer",
-    "image": "mcr.microsoft.com/devcontainers/python:3.11",
     "customizations": {
       "vscode": {
         "extensions": [
-          "ms-python.python",           
-          "njpwerner.autodocstring"     
-        ]
+          "ms-python.python",
+          "njpwerner.autodocstring"
+        ],
+        "settings": {
+          // Docstring 스타일: Google 스타일 (읽기 쉬움)
+          "autoDocstring.docstringFormat": "google",
+  
+          // 함수에서 Enter 누르면 자동 생성
+          "autoDocstring.generateDocstringOnEnter": true,
+  
+          // 따옴표 스타일: Python 표준 삼중따옴표
+          "autoDocstring.quoteStyle": "\"\"\"",
+  
+          // 파라미터 이름 포함
+          "autoDocstring.includeName": true,
+  
+          // 타입 힌트도 자동 포함 (힌트가 있을 경우)
+          "autoDocstring.includeTypeHint": true,
+
+          // 함수 정의 다음 줄에서 바로 시작 (줄바꿈 없음)
+          "autoDocstring.startOnNewLine": false
+        }
       }
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "Python RepoScore DevContainer",
+    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-python.python",           
+          "njpwerner.autodocstring"     
+        ]
+      }
+    }
+  }
+  


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/587

## Specific Version
https://github.com/oss2025hnu/reposcore-py/commit/7db0aa2ecd25ba49b36724930693ddcea7cae136

## 변경 내용
- `.devcontainer/devcontainer.json` 파일에 `njpwerner.autodocstring` 확장 추가
- autoDocstring 확장 기본 설정을 포함 (google 스타일, Enter 입력 시 생성, 삼중따옴표 사용)
