### PR TITLE
--help 출력에서 --format 옵션 기본값이 all 이라는 내용 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ options:
   --output dir_name     분석 결과를 저장할 출력 디렉토리 (기본값: 'results')
   --format {table, text, chart, all} [{table, text, chart, all} ...]
                         결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart)
+                        (기본값:'all')
   --grade               차트에 등급 표시
   --use-cache           participants 데이터를 캐시에서 불러올지 여부 (기본: API를 통해 새로 수집)
   --token TOKEN         API 요청 제한 해제를 위한 깃허브 개인 액세스 토큰

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -102,7 +102,7 @@ def parse_arguments() -> argparse.Namespace:
         nargs='+',
         default=[FORMAT_ALL],
         metavar=f"{{{VALID_FORMATS_DISPLAY}}}",
-        help =  f"결과 출력 형식 선택 (복수 선택 가능, 예: --format {FORMAT_TABLE} {FORMAT_CHART})"
+        help =  f"결과 출력 형식 선택 (복수 선택 가능, 예: --format {FORMAT_TABLE} {FORMAT_CHART}) (기본값:'{FORMAT_ALL}')"
     )
     parser.add_argument(
         "--grade",


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/599

## Specific Version
https://github.com/oss2025hnu/reposcore-py/commit/fbfb21c67786edb47fdf1ebcfd9f5bb41710a55e

## 변경 내용
- --help 출력에서 --format 옵션 기본값이 all 이라는 내용 추가
```
  --format {table, text, chart, all} [{table, text, chart, all} ...]
                        결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart)
                        (기본값:'all')
```