### PR TITLE
[FEAT] 차트에서 "순위 이름" 대신 "이름 순위"로 나타나도록 변경에 대한 PR (#608)

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -559,7 +559,7 @@ class RepoAnalyzer:
         ranked_participants = []
         for i, participant in enumerate(participants):
             rank_suffix = get_ordinal_suffix(ranks[i])
-            ranked_participants.append(f"{rank_suffix} {participant}")
+            ranked_participants.append(f"{participant} ({rank_suffix})")
 
         plt.figure(figsize=(self.CHART_CONFIG['figure_width'], height))
         bars = plt.barh(ranked_participants, scores_sorted, height=self.CHART_CONFIG['bar_height'])


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/608

## Specific Version
c4999730aca3029052f72b07ad7991dbba9cccea

## 변경 내용
변경 전: "1st username", "2nd username" 등
변경 후: "username (1st)", "username (2nd)" 등
이슈에서 보여준 예시처럼 이름이 먼저 나오고 뒤에 괄호 안에 순위가 표시되도록 기능을 수정하였습니다.

## 스크린샷

![image](https://github.com/user-attachments/assets/73198a4b-21e6-4378-b56d-4c3274c8036c)

