### PR TITLE
다크 테마에서 활동 비율 텍스트 배경색 가독성 문제 해결

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -627,7 +627,12 @@ class RepoAnalyzer:
                 f'{score_text}\n{ratio_text}',
                 va='center',
                 fontsize=self.CHART_CONFIG['font_size'],
-                bbox=dict(facecolor='white', alpha=0.8, pad=self.CHART_CONFIG['text_padding'], edgecolor='none'),
+                bbox=dict(
+                    facecolor=theme['chart']['style']['background'],  # 수정: 다크/라이트 테마에 따라 배경색 적용
+                    alpha=0.8,
+                    pad=self.CHART_CONFIG['text_padding'],
+                    edgecolor='none'
+                ),
                 clip_on=False
             )
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/601

## Specific Version
https://github.com/oss2025hnu/reposcore-py/commit/0e9cfebd629c4262a24611253bd668dd87285a9c

## 변경 내용
- 다크 테마에서 활동 비율 텍스트 배경색이 흰색으로 출력되어 가독성이 떨어지는 문제를 해결했습니다.
- `generate_chart` 메서드에서 텍스트 배경색을 다크/라이트 테마에 따라 동적으로 설정하도록 수정했습니다.
  - 기존 하드코딩된 `'white'` 배경색을 제거하고, `theme['chart']['style']['background']` 값을 사용하도록 변경했습니다.
- 텍스트 배경 상자(`bbox`)의 `facecolor`를 테마에 맞게 설정하여 다크 테마에서도 가독성을 확보했습니다.
![image](https://github.com/user-attachments/assets/037cc562-bdfc-4cb9-92b0-b1020dd85581)

