### PR TITLE
[DOC] 한국 시간대 설정 가이드에서 workflow 내용 대체 필요 에 대한 PR

### DIFF
--- a/docs/korean-timezone-guide.md
+++ b/docs/korean-timezone-guide.md
@@ -1,6 +1,5 @@
 ## 한국 시간대(Asia/Seoul) 설정 가이드
 
-
 ### Codespaces에서 한국 시간대 적용하기
 
 Codespaces 터미널에서 아래 명령어를 입력하세요:
@@ -16,27 +15,35 @@ echo 'export TZ=Asia/Seoul' >> ~/.bashrc
 source ~/.bashrc
 ```
 
----
+### devcontainer.json을 통한 한국 시간대 설정
 
-### GitHub Actions에서 시간대 변경하기
+Codespaces의 개발 환경은 `devcontainer.json`을 통해 설정할 수 있습니다. 저장소 루트의 `.devcontainer/devcontainer.json` 파일에 다음을 추가하여 한국 시간대(`Asia/Seoul`)를 설정하세요:
 
-`.github/workflows/ci.yml` 같은 워크플로우 파일에 다음을 추가합니다:
+```json
+{
+  "name": "Your Codespace",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "runArgs": ["--env", "TZ=Asia/Seoul"],
+  "containerEnv": {
+    "TZ": "Asia/Seoul"
+  }
+}
+```
 
-```yaml
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set timezone to Asia/Seoul
-        run: |
-          sudo ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
-          echo "Asia/Seoul" | sudo tee /etc/timezone
+- **`runArgs`**: 컨테이너 실행 시 환경 변수 설정.
+- **`containerEnv`**: 컨테이너 내부의 환경 변수 정의.
+- **주의**: `devcontainer.json`이 없는 경우, 저장소에 `.devcontainer/` 디렉토리와 파일을 생성해야 합니다. 이 작업은 별도 이슈로 처리하세요.
+
+설정 후 Codespaces를 재빌드하면 한국 시간대가 자동 적용됩니다:
+
+```bash
+# Codespaces 재빌드
+gh codespace rebuild
 ```
 
 ---
 
 ### 주의사항
 
-- Python `datetime.now()`는 OS의 기본 시간대를 따르므로 위 설정이 되어 있어야 한국 시간으로 로그가 표시됩니다.
+- Python `datetime.now()`는 OS의 기본 시간대를 따르�므로 위 설정이 되어 있어야 한국 시간으로 로그가 표시됩니다.
 - 시스템 시간 설정이 불가한 환경이라면 `datetime.now(tz=...)` 사용을 고려할 수 있습니다.
-


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/613

## Specific Version
d7c5f95e8ed6ec32e87ef37c5981d95dabd48a9c

## 변경 내용
- GitHub Actions 워크플로우 시간대 설정 섹션 삭제 (Codespaces와 무관).
- devcontainer.json을 통한 한국 시간대(Asia/Seoul) 설정 방법 추가.
- 기존 .bashrc 설정과 주의사항 유지.
