### PR TITLE
[BUG] 차트 한글 폰트 깨짐 이슈

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,16 @@ update-fonts: requirements
 	$(PYTHON) -c "import shutil; import matplotlib; shutil.rmtree(matplotlib.get_cachedir())"
 
 install-fonts:
-	@echo "Detected distribution: $(DISTRO)"
+	@echo "🔍 Detecting system..."
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		echo "🍎 macOS detected. Installing NanumGothic via Homebrew..."; \
+		brew tap homebrew/cask-fonts && brew install --cask font-nanum-gothic; \
+	elif [ -f /etc/debian_version ]; then \
+		echo "🐧 Debian/Ubuntu detected. Installing fonts-nanum..."; \
+		sudo apt update && sudo apt install -y fonts-nanum; \
+	else \
+		echo "⚠️ Unsupported OS. Please install a Korean font (NanumGothic) manually."; \
+	fi
 
 ifneq (,$(filter $(DISTRO),Debian Ubuntu))
 	@echo "Installing Noto Sans CJK fonts for Debian..."


### PR DESCRIPTION
## Issue ID 
#624 

## Specific Version
a0f72681ef87aacc684ed88a54d4102410702852

## 변경 내용
기존 Makefile 안에 install-fonts가 실제로 폰트를 설치하지 않아서 한글이 깨지게 됨
Makefile 안에 install-fonts 코드를 사용하고 있는 OS에 맞게 폰트를 설치해주는 코드로 수정함
차트 한글 폰트 깨짐 이슈 해결 가이드를 참고하여
make install-fonts
make update-fonts 순으로 적용하여 결과를 출력하여 확인하면 차트도 한글이 깨져보이지 않음을 확인함