### PR TITLE
-v, --verbose, --user (유저명) 옵션 추가

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -112,6 +112,11 @@ def parse_arguments() -> argparse.Namespace:
     action="store_true",
     help="자세한 로그를 출력합니다."
     )
+    parser.add_argument(
+    "--user",
+    type=str,
+    help="특정 사용자의 점수와 등수를 출력합니다 (GitHub 사용자명)"
+    )
     return parser.parse_args()
 
 def merge_participants(
@@ -224,6 +229,18 @@ def main() -> None:
             # 스코어 계산
             repo_scores = analyzer.calculate_scores(user_info)
 
+            # --user 옵션이 지정된 경우 사용자 점수 및 등수 출력
+            user_lookup_name = user_info.get(args.user, args.user) if args.user and user_info else args.user
+            if args.user and user_lookup_name in repo_scores:
+                sorted_users = list(repo_scores.keys())
+                user_rank = sorted_users.index(user_lookup_name) + 1
+                user_score = repo_scores[user_lookup_name]["total"]
+                log(f"[INFO] 사용자: {user_lookup_name}", force=True)
+                log(f"[INFO] 총점: {user_score:.2f}점", force=True)
+                log(f"[INFO] 등수: {user_rank}등 (전체 {len(sorted_users)}명 중)", force=True)
+            elif args.user:
+                log(f"[INFO] 사용자 '{args.user}'의 점수가 계산된 결과에 없습니다.", force=True)
+
             # 출력 형식
             formats = set(args.format)
             if FORMAT_ALL in formats:
@@ -271,6 +288,18 @@ def main() -> None:
         
         # 통합 점수 계산
         overall_scores = overall_analyzer.calculate_scores(user_info)
+
+        # --user 옵션이 지정된 경우 통합 점수에서 출력
+        user_lookup_name = user_info.get(args.user, args.user) if args.user and user_info else args.user
+        if args.user and user_lookup_name in overall_scores:
+            sorted_users = list(overall_scores.keys())
+            user_rank = sorted_users.index(user_lookup_name) + 1
+            user_score = overall_scores[user_lookup_name]["total"]
+            log(f"[INFO] 사용자: {user_lookup_name}", force=True)
+            log(f"[INFO] 총점: {user_score:.2f}점", force=True)
+            log(f"[INFO] 등수: {user_rank}등 (전체 {len(sorted_users)}명 중)", force=True)
+        elif args.user:
+            log(f"[INFO] 사용자 '{args.user}'의 점수가 통합 분석 결과에 없습니다.", force=True)
         
         # 통합 결과 저장
         overall_output_dir = os.path.join(args.output, "overall")

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -12,6 +12,7 @@ from .common_utils import *
 from .github_utils import *
 from .analyzer import RepoAnalyzer
 from .output_handler import OutputHandler
+from . import common_utils
 
 # 포맷 상수
 FORMAT_TABLE = "table"
@@ -106,6 +107,11 @@ def parse_arguments() -> argparse.Namespace:
         default="default",
         help="테마 선택 (default 또는 dark)"
     )
+    parser.add_argument(
+    "-v", "--verbose",
+    action="store_true",
+    help="자세한 로그를 출력합니다."
+    )
     return parser.parse_args()
 
 def merge_participants(
@@ -126,6 +132,7 @@ def merge_participants(
 def main() -> None:
     """Main execution function"""
     args = parse_arguments()
+    common_utils.is_verbose = args.verbose
     github_token = args.token
     if not args.token:
         github_token = os.getenv('GITHUB_TOKEN')
@@ -171,13 +178,13 @@ def main() -> None:
             logging.warning(f"입력한 저장소 '{repo}'가 깃허브에 존재하지 않을 수 있음.")
             sys.exit(1)
 
-    logging.info(f"저장소 분석 시작: {', '.join(final_repositories)}")
+    log(f"저장소 분석 시작: {', '.join(final_repositories)}", force=True)
 
     overall_participants = {}
     
     #저장소별로 분석 후 '개별 결과'도 저장하기
     for repo in final_repositories:
-        logging.info(f"분석 시작: {repo}")
+        log(f"분석 시작: {repo}", force=True)
 
         analyzer = RepoAnalyzer(repo, token=github_token, theme=args.theme)
         output_handler = OutputHandler(theme=args.theme)
@@ -191,16 +198,16 @@ def main() -> None:
         cache_update_required = os.path.exists(cache_path) and analyzer.is_cache_update_required(cache_path)
 
         if args.use_cache and os.path.exists(cache_path) and not cache_update_required:
-            logging.info(f"✅ 캐시 파일({cache_file_name})이 존재합니다. 캐시에서 데이터를 불러옵니다.")
+            log(f"✅ 캐시 파일({cache_file_name})이 존재합니다. 캐시에서 데이터를 불러옵니다.", force=True)
             with open(cache_path, "r", encoding="utf-8") as f:
                 cached_json = json.load(f)
                 analyzer.participants = cached_json['participants']
                 analyzer.previous_create_at = cached_json['update_time']
         else:
             if args.use_cache and cache_update_required:
-                logging.info(f"🔄 리포지토리의 최근 이슈 생성 시간이 캐시파일의 생성 시간보다 최근입니다. GitHub API로 데이터를 수집합니다.")
+                log(f"🔄 리포지토리의 최근 이슈 생성 시간이 캐시파일의 생성 시간보다 최근입니다. GitHub API로 데이터를 수집합니다.", force=True)
             else:
-                logging.info(f"�� 캐시를 사용하지 않거나 캐시 파일({cache_file_name})이 없습니다. GitHub API로 데이터를 수집합니다.")
+                log(f"�� 캐시를 사용하지 않거나 캐시 파일({cache_file_name})이 없습니다. GitHub API로 데이터를 수집합니다.", force=True)
             analyzer.collect_PRs_and_issues()
             if not getattr(analyzer, "_data_collected", True):
                 logging.error("❌ GitHub API 요청에 실패했습니다. 결과 파일을 생성하지 않고 종료합니다.")
@@ -232,20 +239,20 @@ def main() -> None:
                 table_path = os.path.join(repo_output_dir, "score.csv")
                 output_handler.generate_table(repo_scores, save_path=table_path)
                 output_handler.generate_count_csv(repo_scores, save_path=table_path)
-                logging.info(f"[개별 저장소] CSV 파일 저장 완료: {table_path}")
+                log(f"CSV 파일 저장 완료: {table_path}", force=True)
 
             # 2) 텍스트 테이블 저장
             if FORMAT_TEXT in formats:
                 txt_path = os.path.join(repo_output_dir, "score.txt")
                 output_handler.generate_text(repo_scores, txt_path)
-                logging.info(f"[개별 저장소] 텍스트 파일 저장 완료: {txt_path}")
+                log(f"텍스트 파일 저장 완료: {txt_path}", force=True)
 
             # 3) 차트 이미지 저장
             if FORMAT_CHART in formats:
                 chart_filename = "chart_grade.png" if args.grade else "chart.png"
                 chart_path = os.path.join(repo_output_dir, chart_filename)
                 output_handler.generate_chart(repo_scores, save_path=chart_path, show_grade=args.grade)
-                logging.info(f"[개별 저장소] 차트 이미지 저장 완료: {chart_path}")
+                log(f"차트 이미지 저장 완료: {chart_path}", force=True)
 
             # 전체 참여자 데이터 병합
             overall_participants = merge_participants(overall_participants, analyzer.participants)
@@ -256,7 +263,7 @@ def main() -> None:
 
     # 전체 저장소 통합 분석
     if len(final_repositories) > 1:
-        logging.info("\n=== 전체 저장소 통합 분석 ===")
+        log("\n=== 전체 저장소 통합 분석 ===", force=True)
         
         # 통합 분석을 위한 analyzer 생성
         overall_analyzer = RepoAnalyzer("multiple_repos", token=github_token, theme=args.theme)
@@ -274,20 +281,20 @@ def main() -> None:
             table_path = os.path.join(overall_output_dir, "score.csv")
             output_handler.generate_table(overall_scores, save_path=table_path)
             output_handler.generate_count_csv(overall_scores, save_path=table_path)
-            logging.info(f"[통합 저장소] CSV 파일 저장 완료: {table_path}")
+            log(f"[통합 저장소] CSV 파일 저장 완료: {table_path}", force=True)
         
         # 2) 텍스트 테이블 저장
         if FORMAT_TEXT in formats:
             txt_path = os.path.join(overall_output_dir, "score.txt")
             output_handler.generate_text(overall_scores, txt_path)
-            logging.info(f"[통합 저장소] 텍스트 파일 저장 완료: {txt_path}")
+            log(f"[통합 저장소] 텍스트 파일 저장 완료: {txt_path}", force=True)
         
         # 3) 차트 이미지 저장
         if FORMAT_CHART in formats:
             chart_filename = "chart_grade.png" if args.grade else "chart.png"
             chart_path = os.path.join(overall_output_dir, chart_filename)
             output_handler.generate_chart(overall_scores, save_path=chart_path, show_grade=args.grade)
-            logging.info(f"[통합 저장소] 차트 이미지 저장 완료: {chart_path}")
+            log(f"[통합 저장소] 차트 이미지 저장 완료: {chart_path}", force=True)
 
 if __name__ == "__main__":
     main()

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -4,7 +4,7 @@ import requests
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-from .common_utils import *
+from .common_utils import log, is_verbose
 from .github_utils import *
 from .theme_manager import ThemeManager 
 
@@ -61,9 +61,9 @@ class RepoAnalyzer:
                 logging.error(f"입력한 저장소 '{repo_path}'가 GitHub에 존재하지 않습니다.")
                 sys.exit(1)
         elif self._is_test_repo:
-            logging.info(f"ℹ️ [TEST MODE] '{repo_path}'는 테스트용 저장소로 간주합니다.")
+            log(f"ℹ️ [TEST MODE] '{repo_path}'는 테스트용 저장소로 간주합니다.", force=True)
         elif self._is_multiple_repos:
-            logging.info(f"ℹ️ [통합 분석] 여러 저장소의 통합 분석을 수행합니다.")
+            log(f"ℹ️ [통합 분석] 여러 저장소의 통합 분석을 수행합니다.", force=True)
 
         self.repo_path = repo_path
         self.participants: dict[str, dict[str, int]] = {}
@@ -203,9 +203,9 @@ class RepoAnalyzer:
                 user: info for user, info in self.participants.items()
                 if user not in self.EXCLUDED_USERS
             }
-            logging.info("\n참여자별 활동 내역 (participants 딕셔너리):")
+            log("\n참여자별 활동 내역 (participants 딕셔너리):", force=is_verbose)
             for user, info in self.participants.items():
-                logging.info(f"{user}: {info}")
+                log(f"{user}: {info}", force=is_verbose)
 
     def _extract_pr_counts(self, activities: dict) -> tuple[int, int, int, int, int]:
         """PR 관련 카운트 추출"""

--- a/reposcore/common_utils.py
+++ b/reposcore/common_utils.py
@@ -1,6 +1,10 @@
 import sys
 import logging
 
+from datetime import datetime
+
+is_verbose = False
+
 # logging 모듈 기본 설정 (analyzer.py와 동일한 설정)
 logging.basicConfig(
     stream=sys.stdout,
@@ -21,3 +25,9 @@ def get_ordinal_suffix(rank):
         return f"{rank}rd"
     else:
         return f"{rank}th"
+
+# -v or --vebose 옵션에 따라 로그를 다르게 출력하는 함수
+def log(message: str, force: bool = False):
+    if is_verbose or force:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print(f"[{timestamp}] {message}")

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -8,10 +8,9 @@ from prettytable import PrettyTable
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-from .common_utils import *
-from .theme_manager import ThemeManager 
+from .common_utils import log
+from .theme_manager import ThemeManager
 
-import logging
 import sys
 import os
 


### PR DESCRIPTION
## Issue ID 
[FEAT]프로그램 실행 시 CLI창에 출력되는 참여자별 활동 내역 (participants 딕셔너리)을 선택적 표시 옵션 추가 요청 https://github.com/oss2025hnu/reposcore-py/issues/469 및
--user 옵션으로 본인 닉네임 입력 시 총점과 등수 출력 기능 추가 https://github.com/oss2025hnu/reposcore-py/issues/643 에 대한 PR입니다.

## Specific Version
750b7e62f542d77672c74951d655735c1e4ec446

## 변경 내용
issue 및 교수님의 말씀에 따라 -v 또는 --verbose 옵션을 추가하여 participants 딕셔너리를 로그 내역에서 선택적으로 출력할 수 있도록 수정했습니다.
<img width="982" alt="스크린샷 2025-05-01 오후 5 04 10" src="https://github.com/user-attachments/assets/afd29f73-70bc-4873-bbf2-20a99abe591e" />
추가로 --user (유저명) 명령어 입력 시 원하는 유저의 정보만 출력하도록 하였습니다.

## --user (유저명) 옵션 실행 결과
```python -m reposcore oss2025hnu/reposcore-py --user Sernn0```

```
[2025-05-01 14:23:32] [INFO] 사용자: Sernn0
[2025-05-01 14:23:32] [INFO] 총점: 18.00점
[2025-05-01 14:23:32] [INFO] 등수: 13등 (전체 69명 중)
