### PR TITLE
cs 저장소 최대 점수 15점 제한

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -297,6 +297,10 @@ class RepoAnalyzer:
             # 총점 계산
             total = self._calculate_total_score(p_fb_at, p_d_at, p_t_at, i_fb_at, i_d_at)
             
+            # cs 저장소라면 15점으로 제한
+            if "reposcore-cs" in self.repo_path:
+                total = min(total, 15)
+
             scores[participant] = self._create_score_dict(p_fb_at, p_d_at, p_t_at, i_fb_at, i_d_at, total)
             total_score_sum += total
 


### PR DESCRIPTION
## Issue ID 
15점 초과 이후 reposcore-cs 저장소 활동 점수 무효화 로직 추가 https://github.com/oss2025hnu/reposcore-py/issues/644 에 대한 PR입니다.

## Specific Version
a8779dc4b0f6a5c5cc21db9f46efc08ddc03d03d

## 변경 내용
analyzer.py 파일의 calculate_scores() 하단에 아래 코드를 추가하여 cs 저장소의 최대 점수가 15점까지만 인정되도록 수정했습니다.
```
if "reposcore-cs" in self.repo_path:
    total = min(total, 15)
