### PR TITLE
참여자별 점수 출력에 등수 정보 추가

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -20,11 +20,11 @@ class OutputHandler:
     # 차트 설정
     CHART_CONFIG = {
         'height_per_participant': 0.4,  # 참여자당 차트 높이
-        'min_height': 3.0,             # 최소 차트 높이
-        'bar_height': 0.5,             # 막대 높이
-        'figure_width': 12,            # 차트 너비 (텍스트 잘림 방지 위해 증가)
-        'font_size': 9,                # 폰트 크기
-        'text_padding': 0.1            # 텍스트 배경 상자 패딩
+        'min_height': 3.0,              # 최소 차트 높이
+        'bar_height': 0.5,              # 막대 높이
+        'figure_width': 12,             # 차트 너비 (텍스트 잘림 방지 위해 증가)
+        'font_size': 9,                 # 폰트 크기
+        'text_padding': 0.1             # 텍스트 배경 상자 패딩
     }
     
     # 등급 기준
@@ -57,12 +57,16 @@ class OutputHandler:
     def generate_table(self, scores: dict[str, dict[str, float]], save_path) -> None:
         """결과를 테이블 형태로 출력"""
         table = PrettyTable()
-        table.field_names = ["참여자", "총점", "등급", "PR(기능/버그)", "PR(문서)", "PR(오타)", "이슈(기능/버그)", "이슈(문서)"]
+        # 등수 컬럼 추가
+        table.field_names = ["등수", "참여자", "총점", "등급", "PR(기능/버그)", "PR(문서)", "PR(오타)", "이슈(기능/버그)", "이슈(문서)"]
         
+        # 등수 카운터 초기화
+        rank = 1
         for name, score in scores.items():
             # 등급 계산
             grade = self._calculate_grade(score['total'])
             row = [
+                rank, # 등수 추가
                 name,
                 f"{score['total']:.1f}",
                 grade,
@@ -73,6 +77,7 @@ class OutputHandler:
                 f"{score['document issue']:.1f}"
             ]
             table.add_row(row)
+            rank += 1 # 등수 증가
         
         with open(save_path, 'w', encoding='utf-8') as f:
             f.write(str(table))
@@ -80,7 +85,7 @@ class OutputHandler:
     def generate_count_csv(self, scores: dict, save_path: str = None) -> None:
         """결과를 CSV 파일로 출력"""
         df = pd.DataFrame.from_dict(scores, orient='index')
-        # grade 컬럼 제거
+        # grade 컬럼 제거 (기존 코드 유지 - 불필요 시 제거 가능)
         df = df.drop('grade', axis=1, errors='ignore')
         df = df.round(1)
         df.index.name = 'name'  # 인덱스 이름을 'name'으로 설정
@@ -91,16 +96,20 @@ class OutputHandler:
         with open(save_path, 'w', encoding='utf-8') as f:
             f.write("=== 참여자별 점수 ===\n\n")
             
+            # 등수 카운터 초기화
+            rank = 1
             for name, score in scores.items():
                 # 등급 계산
                 grade = self._calculate_grade(score['total'])
-                f.write(f"📊 {name}\n")
-                f.write(f"   총점: {score['total']:.1f} ({grade})\n")
-                f.write(f"   PR(기능/버그): {score['feat/bug PR']:.1f}\n")
-                f.write(f"   PR(문서): {score['document PR']:.1f}\n")
-                f.write(f"   PR(오타): {score['typo PR']:.1f}\n")
-                f.write(f"   이슈(기능/버그): {score['feat/bug issue']:.1f}\n")
-                f.write(f"   이슈(문서): {score['document issue']:.1f}\n\n")
+                # 등수 추가하여 출력
+                f.write(f"📊 {rank}위 - {name}\n")
+                f.write(f"    총점: {score['total']:.1f} ({grade})\n")
+                f.write(f"    PR(기능/버그): {score['feat/bug PR']:.1f}\n")
+                f.write(f"    PR(문서): {score['document PR']:.1f}\n")
+                f.write(f"    PR(오타): {score['typo PR']:.1f}\n")
+                f.write(f"    이슈(기능/버그): {score['feat/bug issue']:.1f}\n")
+                f.write(f"    이슈(문서): {score['document issue']:.1f}\n\n")
+                rank += 1 # 등수 증가
 
     def _calculate_activity_ratios(self, participant_scores: dict) -> tuple[float, float, float]:
         """활동 비율 계산"""
@@ -114,7 +123,7 @@ class OutputHandler:
         pr_ratio = total_pr / total
         issue_ratio = total_issue / total
         code_ratio = (sum(score['feat/bug PR'] for score in participant_scores.values()) + 
-                     sum(score['feat/bug issue'] for score in participant_scores.values())) / total
+                      sum(score['feat/bug issue'] for score in participant_scores.values())) / total
 
         return pr_ratio, issue_ratio, code_ratio
 
@@ -124,30 +133,35 @@ class OutputHandler:
         # OSS 한글 폰트인 본고딕, 나눔고딕, 백묵 중 순서대로 하나를 선택
         font_paths = [
             '/usr/share/fonts/truetype/nanum/NanumGothic.ttf',  # 나눔고딕
-            '/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc',  # 본고딕
+            '/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc',  # 본고딕 (NotoSansCJK-Regular.ttc 또는 NotoSansKR-Regular.otf 등)
             '/usr/share/fonts/truetype/baekmuk/baekmuk.ttf'  # 백묵
         ]
         
         for font_path in font_paths:
             if os.path.exists(font_path):
                 fm.fontManager.addfont(font_path)
+                # matplotlib의 기본 폰트 설정을 업데이트하여 한글 지원
                 plt.rcParams['font.family'] = 'sans-serif'
-                plt.rcParams['font.sans-serif'] = ['NanumGothic', 'Noto Sans CJK JP', 'Baekmuk']
+                plt.rcParams['font.sans-serif'] = ['NanumGothic', 'Noto Sans CJK JP', 'Baekmuk'] # 리스트 순서대로 찾음
+                plt.rcParams['axes.unicode_minus'] = False # 마이너스 부호 깨짐 방지 - 추가된 라인
                 break
 
         # 참여자 수에 따라 차트 높이 조정
         num_participants = len(scores)
         chart_height = max(self.CHART_CONFIG['min_height'], 
-                         num_participants * self.CHART_CONFIG['height_per_participant'])
+                           num_participants * self.CHART_CONFIG['height_per_participant'])
 
         # 차트 생성
         fig, ax = plt.subplots(figsize=(self.CHART_CONFIG['figure_width'], chart_height))
         
-        # 데이터 준비
+        # 데이터 준비 (참여자 이름은 등수와 함께 사용)
         participants = list(scores.keys())
         pr_scores = [scores[p]['feat/bug PR'] + scores[p]['document PR'] + scores[p]['typo PR'] for p in participants]
         issue_scores = [scores[p]['feat/bug issue'] + scores[p]['document issue'] for p in participants]
         total_scores = [scores[p]['total'] for p in participants]
+
+        # y축 레이블에 등수 추가
+        ranked_labels = [f"{i+1}위 - {name}" for i, name in enumerate(participants)] # 등수 포함 레이블 생성
 
         # 막대 위치 설정
         y_pos = range(len(participants))
@@ -162,19 +176,21 @@ class OutputHandler:
         ax.barh(y_pos, pr_scores, height=bar_height, label='PR', color=pr_color, edgecolor='none')
         ax.barh(y_pos, issue_scores, left=pr_scores, height=bar_height, label='Issue', color=issue_color, edgecolor='none')
 
-        # 점수 표시
+        # 점수 표시 (텍스트에 등수 포함 여부는 선택 사항 - 여기서는 총점만 표시)
         for i, total in enumerate(total_scores):
+            # 등수 정보를 y축 레이블에서 이미 제공하므로, 여기서는 총점과 등급만 표시하도록 유지
+            # 만약 텍스트 옆에도 등수를 함께 표시하고 싶다면 f'{i+1}위 {total:.1f}' 등으로 수정
             if show_grade:
                 grade = self._calculate_grade(total)
                 ax.text(total + 1, i, f'{total:.1f} ({grade})', 
-                       va='center', fontsize=self.CHART_CONFIG['font_size'])
+                        va='center', fontsize=self.CHART_CONFIG['font_size'])
             else:
                 ax.text(total + 1, i, f'{total:.1f}', 
-                       va='center', fontsize=self.CHART_CONFIG['font_size'])
+                        va='center', fontsize=self.CHART_CONFIG['font_size'])
 
         # 축 설정
         ax.set_yticks(y_pos)
-        ax.set_yticklabels(participants)
+        ax.set_yticklabels(ranked_labels) # 등수 포함 레이블 사용
         ax.set_xlabel('Score')
         ax.set_title('Repository Contribution Scores')
         ax.invert_yaxis()
@@ -191,4 +207,4 @@ class OutputHandler:
 
         # 저장
         plt.savefig(save_path, dpi=300, bbox_inches='tight')
-        plt.close() 
+        plt.close()


### PR DESCRIPTION
## Issue ID 
#658 

## Specific Version
e86a0ea

## 변경 내용
- score.txt : 등수 추가
- chart.png : 차트의 y축 레이블에 'N위 - 참여자이름' 형식으로 등수가 포함 ('위' 글자가 깨져보이나 추가적인 이슈를 위해 그대로 커밋함)
- score.csv의 경우 이미 등수대로기에 추가하지 않음
