### PR TITLE
[REFACT] 참여횟수 count 관련 csv 테이블과 점수 관련 csv 테이블을 통합합니다

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -96,11 +96,11 @@ class OutputHandler:
                 grade = self._calculate_grade(score['total'])
                 f.write(f"📊 {name}\n")
                 f.write(f"   총점: {score['total']:.1f} ({grade})\n")
-                f.write(f"   PR(기능/버그): {score['feat/bug PR']:.1f}\n")
-                f.write(f"   PR(문서): {score['document PR']:.1f}\n")
-                f.write(f"   PR(오타): {score['typo PR']:.1f}\n")
-                f.write(f"   이슈(기능/버그): {score['feat/bug issue']:.1f}\n")
-                f.write(f"   이슈(문서): {score['document issue']:.1f}\n\n")
+                f.write(f"   PR(기능/버그): {int(score['feat/bug PR'] / 3)}회 / {score['feat/bug PR']:.1f}점\n")
+                f.write(f"   PR(문서): {int(score['document PR'] / 2)}회 / {score['document PR']:.1f}점\n")
+                f.write(f"   PR(오타): {int(score['typo PR'] / 1)}회 / {score['typo PR']:.1f}점\n")
+                f.write(f"   이슈(기능/버그): {int(score['feat/bug issue'] / 2)}회 / {score['feat/bug issue']:.1f}점\n")
+                f.write(f"   이슈(문서): {int(score['document issue'] / 1)}회 / {score['document issue']:.1f}점\n\n")
 
     def _calculate_activity_ratios(self, participant_scores: dict) -> tuple[float, float, float]:
         """활동 비율 계산"""


### PR DESCRIPTION
## Issue ID 
#595 

## Specific Version
273c53c1ea072e03ea2066ae4e5fc46c7c754c18

## 변경 내용
이슈의 방향성이 횟수와 점수를 한번에 보기 편하게 하기 위한것이라고 판단
( 혹시 이슈의 방향을 잘못 잡았다면 지적 부탁드립니다 )
csv 파일보다 txt 파일이 사용자가 확인하기 더 쉽다고 보여 txt 파일을 수정
score.txt 파일의 출력 기능을 수정하여 각 PR과 이슈마다 횟수 정보를 추가

![image](https://github.com/user-attachments/assets/bfe16d11-0395-4910-b32c-44fef2fecd53)