### PR TITLE
Rainbow CSV 확장 프로그램 자동 설치 목록 추가

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
       "vscode": {
         "extensions": [
           "ms-python.python",
-          "njpwerner.autodocstring"
+          "njpwerner.autodocstring",
+          "mechatroner.rainbow-csv"
         ],
         "settings": {
           // Docstring 스타일: Google 스타일 (읽기 쉬움)


### PR DESCRIPTION
## Issue ID 
.devcontainer에 Rainbow CSV 추가 https://github.com/oss2025hnu/reposcore-py/issues/667 에 대한 PR입니다.

## Specific Version
66a57e47f1af157b656d934def90180cf3f52ad2

## 변경 내용
.devcontainer에 ``"mechatroner.rainbow-csv"``코드를 추가해 Rainbow CSV 확장 프로그램이 자동으로 설치되도록 하였습니다.
