### PR TITLE
[FEAT] 하나의 저장소 결과 출력 시 overall_repository 생략

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -385,46 +385,47 @@ def main() -> None:
         df = df[["name"] + existing_columns]
         df = df.sort_values(by="total", ascending=False)
         df.to_csv(output_path, encoding="utf-8", index=False)
+    
+    if len(final_repositories) > 1:
+        # 저장 경로 지정하고 생성
+        overall_repo_dir = os.path.join(args.output, "overall_repository")
+        os.makedirs(overall_repo_dir, exist_ok=True)
 
-    # 저장 경로 지정하고 생성
-    overall_repo_dir = os.path.join(args.output, "overall_repository")
-    os.makedirs(overall_repo_dir, exist_ok=True)
+        overall_csv_path = os.path.join(overall_repo_dir, "overall_scores.csv")
+        generate_overall_repository_csv(all_repo_scores, overall_csv_path)
+        log(f"[📊 overall_repository] 저장소별 사용자 점수 CSV 저장 완료: {overall_csv_path}", force=True)
 
-    overall_csv_path = os.path.join(overall_repo_dir, "overall_scores.csv")
-    generate_overall_repository_csv(all_repo_scores, overall_csv_path)
-    log(f"[📊 overall_repository] 저장소별 사용자 점수 CSV 저장 완료: {overall_csv_path}", force=True)
+        # 🔽 텍스트 파일 저장: overall_scores.txt
+        overall_txt_path = os.path.join(overall_repo_dir, "overall_scores.txt")
+        with open(overall_txt_path, "w", encoding="utf-8") as f:
+            sorted_users = sorted(all_repo_scores.keys())
+            
+            # 사용자 점수 재구성 (user_scores: username → repo별 점수)
+            user_scores = defaultdict(dict)
+            for repo_name, repo_scores in all_repo_scores.items():
+                for username, score_dict in repo_scores.items():
+                    user_scores[username][repo_name] = score_dict["total"]
 
-    # 🔽 텍스트 파일 저장: overall_scores.txt
-    overall_txt_path = os.path.join(overall_repo_dir, "overall_scores.txt")
-    with open(overall_txt_path, "w", encoding="utf-8") as f:
-        sorted_users = sorted(all_repo_scores.keys())
-        
-        # 사용자 점수 재구성 (user_scores: username → repo별 점수)
-        user_scores = defaultdict(dict)
-        for repo_name, repo_scores in all_repo_scores.items():
-            for username, score_dict in repo_scores.items():
-                user_scores[username][repo_name] = score_dict["total"]
+            # 총점 계산 후 정렬
+            for username in user_scores:
+                user_scores[username]["total"] = sum(user_scores[username].values())
 
-        # 총점 계산 후 정렬
-        for username in user_scores:
-            user_scores[username]["total"] = sum(user_scores[username].values())
+            sorted_users = sorted(user_scores.items(), key=lambda x: x[1]["total"], reverse=True)
 
-        sorted_users = sorted(user_scores.items(), key=lambda x: x[1]["total"], reverse=True)
+            for username, score_dict in sorted_users:
+                f.write(f"📊 {username}\n")
+                f.write(f"총점: {score_dict['total']}점\n")
+                for repo in final_repositories:
+                    repo_key = repo.replace("/", "_")
+                    if repo_key in score_dict:
+                        f.write(f"{repo_key}: {score_dict[repo_key]}점\n")
+                f.write("\n")  # 사용자별 공백 줄
+        log(f"[📊 overall_repository] 저장소별 사용자 점수 TXT 저장 완료: {overall_txt_path}", force=True)
 
-        for username, score_dict in sorted_users:
-            f.write(f"📊 {username}\n")
-            f.write(f"총점: {score_dict['total']}점\n")
-            for repo in final_repositories:
-                repo_key = repo.replace("/", "_")
-                if repo_key in score_dict:
-                    f.write(f"{repo_key}: {score_dict[repo_key]}점\n")
-            f.write("\n")  # 사용자별 공백 줄
-    log(f"[📊 overall_repository] 저장소별 사용자 점수 TXT 저장 완료: {overall_txt_path}", force=True)
-
-    # 📈 통합 차트 이미지 저장
-    chart_path = os.path.join(overall_repo_dir, "chart.png")
-    output_handler.generate_repository_stacked_chart(user_scores, save_path=chart_path)
-    log(f"[📊 overall_repository] 누적 기여도 차트 저장 완료: {chart_path}", force=True)
+        # 📈 통합 차트 이미지 저장
+        chart_path = os.path.join(overall_repo_dir, "chart.png")
+        output_handler.generate_repository_stacked_chart(user_scores, save_path=chart_path)
+        log(f"[📊 overall_repository] 누적 기여도 차트 저장 완료: {chart_path}", force=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Issue ID 
하나의 저장소 결과 출력 시 overall_repository 생략 #704

## Specific Version
13d9fbf

## 변경 내용
- 저장소가 하나일 경우, `overall_repository` 디렉토리 및 관련 결과 파일 생성을 생략하도록 조건문 추가