### PR TITLE
[FEAT] 여러 저장소 분석 시 반복적인 파일 저장 로그 통합

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ $S = 3P_{fb}^* + 2P_d^* + 1P_t^* + 2I_{fb}^* + 1I_d^*$
   - README 자동화 방법.
 - [Pylint 사용 가이드](docs/pylint.md)
   - Pylint를 사용한 검사 기능 사용 방법.
+- [의존성 관리 가이드](docs/dependency_guide.md)
+  - requirements.txt 파일을 통한 라이브러리 관리 및 설치 방법.
 
 ### 🔗 GitHub 관련 기능
 - [GitHub API 가이드](docs/github_api_guide.md)

--- a/docs/dependency_guide.md
+++ b/docs/dependency_guide.md
@@ -1,0 +1,7 @@
+# 의존성 관리 가이드
+
+## 설치 방법
+필요한 라이브러리는 requirements.txt 파일에 명시되어 있습니다.
+
+```bash
+pip install -r requirements.txt

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -251,7 +251,13 @@ def main() -> None:
     all_repo_scores = {}
     
     #저장소별로 분석 후 '개별 결과'도 저장하기
-    from tqdm import tqdm
+    try:
+        from tqdm import tqdm
+    except ImportError:
+        print("[오류] tqdm 라이브러리가 설치되어 있지 않습니다.")
+        print("다음 명령어로 설치 후 다시 실행하세요:")
+        print("pip install tqdm")
+        exit(1)
 
     for repo in tqdm(final_repositories, desc="저장소 분석 진행"):
 

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -251,8 +251,9 @@ def main() -> None:
     all_repo_scores = {}
     
     #저장소별로 분석 후 '개별 결과'도 저장하기
-    for repo in final_repositories:
-        log(f"분석 시작: {repo}", force=True)
+    from tqdm import tqdm
+
+    for repo in tqdm(final_repositories, desc="저장소 분석 진행"):
 
         analyzer = RepoAnalyzer(repo, token=github_token, theme=args.theme)
         output_handler = OutputHandler(theme=args.theme)
@@ -283,9 +284,11 @@ def main() -> None:
                 analyzer.previous_create_at = cached_json['update_time']
         else:
             if args.use_cache and cache_update_required:
-                log(f"🔄 리포지토리의 최근 이슈 생성 시간이 캐시파일의 생성 시간보다 최근입니다. GitHub API로 데이터를 수집합니다.", force=True)
+                if args.verbose:
+                    log(f"🔄 리포지토리의 최근 이슈 생성 시간이 캐시파일의 생성 시간보다 최근입니다. GitHub API로 데이터를 수집합니다.", force=True)
             else:
-                log(f"�� 캐시를 사용하지 않거나 캐시 파일({cache_file_name})이 없습니다. GitHub API로 데이터를 수집합니다.", force=True)
+                if args.verbose:
+                    log(f"�� 캐시를 사용하지 않거나 캐시 파일({cache_file_name})이 없습니다. GitHub API로 데이터를 수집합니다.", force=True)
             analyzer.collect_PRs_and_issues()
             if not getattr(analyzer, "_data_collected", True):
                 logging.error("❌ GitHub API 요청에 실패했습니다. 결과 파일을 생성하지 않고 종료합니다.")
@@ -325,25 +328,36 @@ def main() -> None:
             os.makedirs(repo_output_dir, exist_ok=True)
             all_repo_scores[repo_safe_name] = repo_scores
 
+            results_saved = []
+
             # 1) CSV 테이블 저장
             if FORMAT_TABLE in formats:
                 table_path = os.path.join(repo_output_dir, "score.csv")
                 output_handler.generate_table(repo_scores, save_path=table_path)
                 output_handler.generate_count_csv(repo_scores, save_path=table_path)
-                log(f"CSV 파일 저장 완료: {table_path}", force=True)
+                if args.verbose:
+                    log(f"CSV 파일 저장 완료: {table_path}", force=True)
+                results_saved.append("CSV")
 
             # 2) 텍스트 테이블 저장
             if FORMAT_TEXT in formats:
                 txt_path = os.path.join(repo_output_dir, "score.txt")
                 output_handler.generate_text(repo_scores, txt_path)
-                log(f"텍스트 파일 저장 완료: {txt_path}", force=True)
+                if args.verbose:
+                    log(f"텍스트 파일 저장 완료: {txt_path}", force=True)
+                results_saved.append("TXT")
 
             # 3) 차트 이미지 저장
             if FORMAT_CHART in formats:
                 chart_filename = "chart_grade.png" if args.grade else "chart.png"
                 chart_path = os.path.join(repo_output_dir, chart_filename)
                 output_handler.generate_chart(repo_scores, save_path=chart_path, show_grade=args.grade)
-                log(f"차트 이미지 저장 완료: {chart_path}", force=True)
+                if args.verbose:
+                    log(f"차트 이미지 저장 완료: {chart_path}", force=True)
+                results_saved.append("Chart")
+
+            # 최종 통합 로그 출력
+            log(f"{repo} 분석 결과({', '.join(results_saved)}) 저장 완료: {repo_output_dir}", force=True)    
 
             # 주차별 활동 차트생성
             if args.weekly_chart:
@@ -410,26 +424,37 @@ def main() -> None:
         # 통합 결과 저장
         overall_output_dir = os.path.join(args.output, "overall")
         os.makedirs(overall_output_dir, exist_ok=True)
+
+        results_saved = []
         
         # 1) CSV 테이블 저장
         if FORMAT_TABLE in formats:
             table_path = os.path.join(overall_output_dir, "score.csv")
             output_handler.generate_table(overall_scores, save_path=table_path)
             output_handler.generate_count_csv(overall_scores, save_path=table_path)
-            log(f"[통합 저장소] CSV 파일 저장 완료: {table_path}", force=True)
-        
+            if args.verbose:
+                log(f"[통합 저장소] CSV 파일 저장 완료: {table_path}", force=True)
+            results_saved.append("CSV")
+
         # 2) 텍스트 테이블 저장
         if FORMAT_TEXT in formats:
             txt_path = os.path.join(overall_output_dir, "score.txt")
             output_handler.generate_text(overall_scores, txt_path)
-            log(f"[통합 저장소] 텍스트 파일 저장 완료: {txt_path}", force=True)
+            if args.verbose:
+                log(f"[통합 저장소] 텍스트 파일 저장 완료: {txt_path}", force=True)
+            results_saved.append("TXT")
         
         # 3) 차트 이미지 저장
         if FORMAT_CHART in formats:
             chart_filename = "chart_grade.png" if args.grade else "chart.png"
             chart_path = os.path.join(overall_output_dir, chart_filename)
             output_handler.generate_chart(overall_scores, save_path=chart_path, show_grade=args.grade)
-            log(f"[통합 저장소] 차트 이미지 저장 완료: {chart_path}", force=True)
+            if args.verbose:
+                log(f"[통합 저장소] 차트 이미지 저장 완료: {chart_path}", force=True)
+            results_saved.append("Chart")
+
+        # 최종 통합 로그
+        log(f"[통합 저장소] 분석 결과({', '.join(results_saved)}) 저장 완료: {overall_output_dir}", force=True)
 
     # 사용자별 저장소별 점수 CSV 만드는 함수
     def generate_overall_repository_csv(all_repo_scores, output_path):
@@ -463,9 +488,13 @@ def main() -> None:
         overall_repo_dir = os.path.join(args.output, "overall_repository")
         os.makedirs(overall_repo_dir, exist_ok=True)
 
+        results_saved = []
+
         overall_csv_path = os.path.join(overall_repo_dir, "overall_scores.csv")
         generate_overall_repository_csv(all_repo_scores, overall_csv_path)
-        log(f"[📊 overall_repository] 저장소별 사용자 점수 CSV 저장 완료: {overall_csv_path}", force=True)
+        if args.verbose:
+            log(f"[📊 overall_repository] 저장소별 사용자 점수 CSV 저장 완료: {overall_csv_path}", force=True)
+        results_saved.append("CSV")
 
         # 🔽 텍스트 파일 저장: overall_scores.txt
         overall_txt_path = os.path.join(overall_repo_dir, "overall_scores.txt")
@@ -492,12 +521,19 @@ def main() -> None:
                     if repo_key in score_dict:
                         f.write(f"{repo_key}: {score_dict[repo_key]}점\n")
                 f.write("\n")  # 사용자별 공백 줄
-        log(f"[📊 overall_repository] 저장소별 사용자 점수 TXT 저장 완료: {overall_txt_path}", force=True)
+        if args.verbose:
+            log(f"[📊 overall_repository] 저장소별 사용자 점수 TXT 저장 완료: {overall_txt_path}", force=True)
+        results_saved.append("TXT")
 
         # 📈 통합 차트 이미지 저장
         chart_path = os.path.join(overall_repo_dir, "chart.png")
         output_handler.generate_repository_stacked_chart(user_scores, save_path=chart_path)
-        log(f"[📊 overall_repository] 누적 기여도 차트 저장 완료: {chart_path}", force=True)
+        if args.verbose:
+            log(f"[📊 overall_repository] 누적 기여도 차트 저장 완료: {chart_path}", force=True)
+        results_saved.append("Chart")
+
+        log(f"[📊 overall_repository] 분석 결과({', '.join(results_saved)}) 저장 완료: {overall_repo_dir}", force=True)
+        log(f"[📊 overall_repository] 통합 저장소 기준 사용자별 기여도는 '{overall_repo_dir}' 폴더 내 결과 파일에서 확인할 수 있습니다.", force=True)
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas>=1.3.0
 gitpython>=3.1.0
 requests>=2.32.3
 prettytable
+tqdm

--- a/template_README.md
+++ b/template_README.md
@@ -121,6 +121,8 @@ $S = 3P_{fb}^* + 2P_d^* + 1P_t^* + 2I_{fb}^* + 1I_d^*$
   - README 자동화 방법.
 - [Pylint 사용 가이드](docs/pylint.md)
   - Pylint를 사용한 검사 기능 사용 방법.
+- [의존성 관리 가이드](docs/dependency_guide.md)
+  - requirements.txt 파일을 통한 라이브러리 관리 및 설치 방법.
 
 ### 🔗 GitHub 관련 기능
 - [GitHub API 가이드](docs/github_api_guide.md)


### PR DESCRIPTION
## Issue ID 
#696 

## Specific Version
41c89afc71da94d637a017fc10776b01c5c05176

## 변경 내용
1. 진행률 표시 기능 추가 (tqdm 적용)
  - 저장소별 분석 루프에 tqdm을 적용하여 전체 진행 상황을 막대(bar)로 표시
2. 개별 파일 저장 로그 정리
  - csv, txt, chart의 개별 파일 저장 로그는 --verbose 옵션을 사용할 때만 상세히 출력
  - 기본 실행 시 저장소별 "결과 저장 완료" 요약 로그만 출력
3. 캐시 관련 설명성 로그 정리
  - 저장소 분석 시 저장소마다 캐시를 사용하지 않거나 캐시 파일이 없는 경우의 안내 로그가 반복 출력됨
  - 캐시를 사용하지 않거나 캐시 파일이 없는 경우 안내 로그를 --verbose 옵션을 사용할 때만 출력하도록 변경
  - 캐시를 성공적으로 사용할 때는 기존처럼 안내 로그를 출력 (정상 동작 여부는 항상 표시)
4. 통합 저장소(overall_repository) 결과 안내 추가
  - 전체 통합 분석이 완료되면 사용자별 기여도는 결과 파일에서 확인할 수 있다는 안내 문구 추가

* 요약
  - 코드 실행 시 오류 없음
  - verbose 옵션을 통해 상세 로그 출력 가능
  - 기본 실행 시 불필요한 중복 로그 최소화하여 깔끔하게 출력

* 주의사항
  - 진행률 표시를 위해 tqdm 라이브러리가 필요
  - 본 PR은 코드 반영만 포함, requirements.txt 및 README에 설치 가이드 반영은 별도의 이슈 필요

* 여러 저장소 분석 시
![image](https://github.com/user-attachments/assets/6ab853c6-273b-4c0c-800b-65273a76a784)

* 단일 저장소 분석 시
![image](https://github.com/user-attachments/assets/b7b8a9a1-7fd1-41ed-99a7-b74eb440dc75)
