### PR TITLE
txt에 등수 추가

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -109,22 +109,23 @@ class OutputHandler:
 
         table = PrettyTable()
         table.field_names = [
-            "Name", "Total Score", "Grade",
+            "Rank","Name", "Total Score", "Grade",
             "PR (Feature/Bug)", "PR (Docs)", "PR (Typos)",
             "Issue (Feature/Bug)", "Issue (Docs)"
         ]
 
-        for name, score in scores.items():
+        for rank, (name, score) in enumerate(scores.items(), start=1):
             grade = self._calculate_grade(score["total"])
             table.add_row([
+                f"{rank}",
                 name,
-                f"{score['total']:.1f}",
+                f"{score['total']:5.1f}",
                 grade,
-                f"{score['feat/bug PR']:.1f}",
-                f"{score['document PR']:.1f}",
-                f"{score['typo PR']:.1f}",
-                f"{score['feat/bug issue']:.1f}",
-                f"{score['document issue']:.1f}",
+                f"{score['feat/bug PR']:5.1f}",
+                f"{score['document PR']:5.1f}",
+                f"{score['typo PR']:5.1f}",
+                f"{score['feat/bug issue']:5.1f}",
+                f"{score['document issue']:5.1f}",
             ])
 
         with open(save_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/706

## Specific Version
41c89afc71da94d637a017fc10776b01c5c05176

## 변경 내용
텍스트 출력 결과(`score.txt`)에 참여자별  등수(Rank) 정보를 새로 추가했습니다.
순위는 `enumerate(sorted(...), start=1)`를 사용하여 자동 부여하며, 각 행의 가장 앞 열에 표시됩니다.