### PR TITLE
[BUG] make readme 시 불필요한 fontManager 로그 출력됨

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -13,8 +13,6 @@ import pandas as pd
 from .common_utils import *
 from .github_utils import *
 from .analyzer import RepoAnalyzer
-from .output_handler import OutputHandler
-from . import common_utils
 
 # 포맷 상수
 FORMAT_TABLE = "table"
@@ -181,6 +179,8 @@ def merge_participants(
 
 def main() -> None:
     """Main execution function"""
+    from .output_handler import OutputHandler
+    from . import common_utils
     args = parse_arguments()
     common_utils.is_verbose = args.verbose
     github_token = args.token

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -13,6 +13,8 @@ import pandas as pd
 from .common_utils import *
 from .github_utils import *
 from .analyzer import RepoAnalyzer
+from .output_handler import OutputHandler
+from . import common_utils
 
 # 포맷 상수
 FORMAT_TABLE = "table"
@@ -179,8 +181,6 @@ def merge_participants(
 
 def main() -> None:
     """Main execution function"""
-    from .output_handler import OutputHandler
-    from . import common_utils
     args = parse_arguments()
     common_utils.is_verbose = args.verbose
     github_token = args.token

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import json
+import logging
+logging.getLogger('matplotlib').setLevel(logging.WARNING)
+
 import matplotlib.font_manager as fm
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm


### PR DESCRIPTION
## Issue ID 
#694 

## Specific Version
6c379f21d502ffbae2c25d09251c57bb576cd76f

## 변경 내용
OutputHandler 등에서 matplotlib이 즉시 로딩되면서 발생하는 문제로
make readme 명령어 실행 시 발생하던 '[INFO] generated new fontManager' 로그를 제거했습니다.

main.py 파일에서 OutputHandler, common_utils import 위치를 main() 함수 내부로 이동했습니다.

matplotlib 캐시 삭제 후 make readme 명령어 실행 테스트 했을 시 
기존에 뜨던 로그가 출력 안되는 것을 확인했습니다.
나머지 코드들도 정상 작동 확인했습니다.
