### PR TITLE
[BUG] --user 옵션 사용 시 하나의 저장소 결과만 출력되는 문제 해결

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -160,7 +160,7 @@ def handle_individual_user_mode(args):
     else:
         print(f"[INFO] 사용자 '{args.user}'의 점수를 찾을 수 없습니다.")
 
-if args.user:                        
+if args.user and len(args.repository) == 1:
     handle_individual_user_mode(args)
     sys.exit(0)
 
@@ -313,14 +313,14 @@ def main() -> None:
 
             # --user 옵션이 지정된 경우 사용자 점수 및 등수 출력
             user_lookup_name = user_info.get(args.user, args.user) if args.user and user_info else args.user
-            if args.user and user_lookup_name in repo_scores:
+            if args.user and len(final_repositories) == 1 and user_lookup_name in repo_scores:
                 sorted_users = list(repo_scores.keys())
                 user_rank = sorted_users.index(user_lookup_name) + 1
                 user_score = repo_scores[user_lookup_name]["total"]
                 log(f"[INFO] 사용자: {user_lookup_name}", force=True)
                 log(f"[INFO] 총점: {user_score:.2f}점", force=True)
                 log(f"[INFO] 등수: {user_rank}등 (전체 {len(sorted_users)}명 중)", force=True)
-            elif args.user:
+            elif args.user and len(final_repositories) == 1:
                 log(f"[INFO] 사용자 '{args.user}'의 점수가 계산된 결과에 없습니다.", force=True)
 
             # 출력 형식
@@ -414,18 +414,6 @@ def main() -> None:
         
         # 통합 점수 계산
         overall_scores = overall_analyzer.calculate_scores(user_info)
-
-        # --user 옵션이 지정된 경우 통합 점수에서 출력
-        user_lookup_name = user_info.get(args.user, args.user) if args.user and user_info else args.user
-        if args.user and user_lookup_name in overall_scores:
-            sorted_users = list(overall_scores.keys())
-            user_rank = sorted_users.index(user_lookup_name) + 1
-            user_score = overall_scores[user_lookup_name]["total"]
-            log(f"[INFO] 사용자: {user_lookup_name}", force=True)
-            log(f"[INFO] 총점: {user_score:.2f}점", force=True)
-            log(f"[INFO] 등수: {user_rank}등 (전체 {len(sorted_users)}명 중)", force=True)
-        elif args.user:
-            log(f"[INFO] 사용자 '{args.user}'의 점수가 통합 분석 결과에 없습니다.", force=True)
         
         # 통합 결과 저장
         overall_output_dir = os.path.join(args.output, "overall")
@@ -540,6 +528,20 @@ def main() -> None:
 
         log(f"[📊 overall_repository] 분석 결과({', '.join(results_saved)}) 저장 완료: {overall_repo_dir}", force=True)
         log(f"[📊 overall_repository] 통합 저장소 기준 사용자별 기여도는 '{overall_repo_dir}' 폴더 내 결과 파일에서 확인할 수 있습니다.", force=True)
+
+        # --user 옵션이 지정된 경우 통합 점수에서 출력
+        user_lookup_name = user_info.get(args.user, args.user) if args.user and user_info else args.user
+        if args.user and user_lookup_name in overall_scores:
+            sorted_users = list(overall_scores.keys())
+            user_rank = sorted_users.index(user_lookup_name) + 1
+            user_score = overall_scores[user_lookup_name]["total"]
+            print()
+            log(f"[INFO] 사용자: {user_lookup_name}", force=True)
+            log(f"[INFO] 총점: {user_score:.2f}점", force=True)
+            log(f"[INFO] 등수: {user_rank}등 (전체 {len(sorted_users)}명 중)", force=True)
+            print()
+        elif args.user:
+            log(f"[INFO] 사용자 '{args.user}'의 점수가 통합 분석 결과에 없습니다.", force=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/708

## Specific Version
6c379f21d502ffbae2c25d09251c57bb576cd76f

## 변경 내용
 `--user` 옵션 사용 시 단일 저장소만 분석되던 문제를 수정하고, **여러 저장소 입력 시 전체 통합 기준으로 점수 및 등수를 출력**하도록 변경하였습니다.
- 사용자 점수 출력 위치를 모든 로그 출력 이후, 맨 아래로 이동시켜 가독성을 개선했습니다.
- 로그 대신 `print()`를 사용하여 터미널에서 줄바꿈 및 명확한 시각적 구분을 가능하게 했습니다.
- 단일 저장소는 파일이 안만들지만 여러 저장소를 할 경우 파일이 생성됩니다.

출력 예시
=== 전체 저장소 통합 분석 ===
[2025-05-15 11:29:27] ℹ️ [통합 분석] 여러 저장소의 통합 분석을 수행합니다.
[2025-05-15 11:29:29] [통합 저장소] 분석 결과(CSV, TXT, Chart) 저장 완료: results/overall
[2025-05-15 11:29:31] [📊 overall_repository] 분석 결과(CSV, TXT, Chart) 저장 완료: results/overall_repository
[2025-05-15 11:29:31] [📊 overall_repository] 통합 저장소 기준 사용자별 기여도는 'results/overall_repository' 폴더 내 결과 파일에서 확인할 수 있습니다.

[2025-05-15 11:29:31] [INFO] 사용자: jungsuryeon
[2025-05-15 11:29:31] [INFO] 총점: 47.00점
[2025-05-15 11:29:31] [INFO] 등수: 14등 (전체 69명 중)