### PR TITLE
overall_repository 차트 개별 막대그래프 옆에 수치 표시

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -306,6 +306,19 @@ class OutputHandler:
             plt.barh(usernames, scores_by_repo[repo], left=bottom, label=repo.upper(), color=color)
             bottom = [b + s for b, s in zip(bottom, scores_by_repo[repo])]
 
+        # 막대 옆에 총점 수치 표시
+        for i, user in enumerate(usernames):
+            total_score = sum(scores[user].get(repo, 0) for repo in repo_keys)
+            plt.text(
+                bottom[i] + 1,  # 막대 끝에서 오른쪽으로 1만큼 띄움
+                i,              # y 좌표 (사용자 위치)
+                f"{total_score:.1f}",  # 소수점 1자리로 점수 표시
+                va='center',
+                fontsize=9,
+                color='black'
+            )
+
+
         plt.xlabel("점수")
         plt.title("사용자별 저장소 기여도 (py/js/cs)")
         plt.legend(loc="upper right")


### PR DESCRIPTION
## Issue ID 
#703 

## Specific Version
5e9045f2d156fd223cd17f13afb6a70faf828066

## 변경 내용
overall_repository 에 생성되는 차트의 막대그래프 옆에도
숫자로 자신의 총 점수가 몇인지 확인할 수 있게 수정했습니다.
![image](https://github.com/user-attachments/assets/5c04a532-ed11-4bb8-8df8-dd6d5aea207e)
