### PR TITLE
일부 사용자에게 reposcore-cs 저장소 점수가 미반영

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -300,6 +300,36 @@ class RepoAnalyzer:
             
             # 유효 카운트 계산
             p_valid, i_valid = self._calculate_valid_counts(p_fb, p_d, p_t, i_fb, i_d)
+
+            # ✅ PR 0개인데 이슈만 있는 경우 1:4 규칙 보정
+            if p_fb == 0 and i_fb + i_d > 0:
+                # PR은 없지만, 이슈를 위해 PR 1개 있다고 간주 (계산용)
+                p_valid = 1
+                i_valid = min(i_fb + i_d, 4 * p_valid)
+
+                # 💡 실제 PR 점수는 0으로 고정
+                p_fb_at = 0
+                p_d_at = 0
+                p_t_at = 0
+                i_fb_at = min(i_fb, i_valid)
+                i_d_at = i_valid - i_fb_at
+
+                total = (
+                    self.score['feat_bug_is'] * i_fb_at +
+                    self.score['doc_is'] * i_d_at
+                )
+
+                scores[participant] = {
+                    "feat/bug PR": 0.0,
+                    "document PR": 0.0,
+                    "typo PR": 0.0,
+                    "feat/bug issue": self.score['feat_bug_is'] * i_fb_at,
+                    "document issue": self.score['doc_is'] * i_d_at,
+                    "total": total
+                }
+
+                total_score_sum += total
+                continue
             
             # 조정된 카운트 계산
             p_fb_at, p_d_at, p_t_at, i_fb_at, i_d_at = self._calculate_adjusted_counts(

--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -310,13 +310,14 @@ class RepoAnalyzer:
                 # 💡 실제 PR 점수는 0으로 고정
                 p_fb_at = 0
                 p_d_at = 0
-                p_t_at = 0
+                p_t_at = 1 if p_t > 0 else 0  # typo 1개 있으면 점수 부여
                 i_fb_at = min(i_fb, i_valid)
                 i_d_at = i_valid - i_fb_at
 
                 total = (
                     self.score['feat_bug_is'] * i_fb_at +
-                    self.score['doc_is'] * i_d_at
+                    self.score['doc_is'] * i_d_at +
+                    self.score['typo_pr'] * p_t_at
                 )
 
                 scores[participant] = {

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -110,7 +110,7 @@ def test_example_calculate_scores():
 
     scores = analyzer.calculate_scores()
     assert scores["test_user1"]['total'] == 26, "test_user1 결과값이 일치하지 않습니다."
-    assert scores["test_user2"]['total'] == 4, "test_user2 결과값이 일치하지 않습니다."
+    assert scores["test_user2"]['total'] == 5,"test_user2 결과값이 일치하지 않습니다."
     assert scores["test_user3"]['total'] == 79, "test_user3 결과값이 일치하지 않습니다."
     assert scores["test_user4"]['total'] == 9, "test_user4 결과값이 일치하지 않습니다."
     assert scores["test_user5"]['total'] == 7, "test_user5 결과값이 일치하지 않습니다."

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3,59 +3,58 @@ import tempfile
 from reposcore.analyzer import RepoAnalyzer
 from reposcore.output_handler import OutputHandler
 
-
 def test_example_calculate_scores():
     analyzer = RepoAnalyzer("oss2025hnu/reposcore-py")
     analyzer.participants = {
-        "test_user1": {
+        "test_user1": {  # 26 = 3*3 + 2*3 + 1*1 + 2*2 + 2*1
             "p_enhancement": 2,
             "p_bug": 1,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 3,
             "i_enhancement": 2,
             "i_bug": 2,
             "i_documentation": 2,
         },
-        "test_user2": {
+        "test_user2": {  # 5 = 1 typo + 4 doc issues (1:4 보정)
             "p_enhancement": 0,
             "p_bug": 0,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 10,
             "i_enhancement": 0,
             "i_bug": 0,
             "i_documentation": 10,
         },
-        "test_user3": {
+        "test_user3": {  # 79점 
             "p_enhancement": 3,
             "p_bug": 3,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 20,
             "i_enhancement": 5,
             "i_bug": 5,
             "i_documentation": 5,
         },
-        "test_user4": {
+        "test_user4": {  # 9 = 3+2+1+2+1
             "p_enhancement": 1,
             "p_bug": 1,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 1,
             "i_enhancement": 0,
             "i_bug": 0,
             "i_documentation": 0,
         },
-        "test_user5": {
+        "test_user5": {  # 7 = 3+1+3 (p_valid=2)
             "p_enhancement": 2,
             "p_bug": 0,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 0,
             "i_enhancement": 0,
             "i_bug": 0,
             "i_documentation": 0,
         },
-        "test_user6": {
+        "test_user6": {  # 9 = 1 typo + 4 issues * 2 = 8
             "p_enhancement": 0,
             "p_bug": 0,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 0,
             "i_enhancement": 3,
             "i_bug": 3,
@@ -64,7 +63,7 @@ def test_example_calculate_scores():
         "test_user7": {
             "p_enhancement": 2,
             "p_bug": 2,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 12,
             "i_enhancement": 4,
             "i_bug": 4,
@@ -73,7 +72,7 @@ def test_example_calculate_scores():
         "test_user8": {
             "p_enhancement": 0,
             "p_bug": 2,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 6,
             "i_enhancement": 1,
             "i_bug": 1,
@@ -82,7 +81,7 @@ def test_example_calculate_scores():
         "test_user9": {
             "p_enhancement": 0,
             "p_bug": 2,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 5,
             "i_enhancement": 2,
             "i_bug": 0,
@@ -91,16 +90,16 @@ def test_example_calculate_scores():
         "test_user10": {
             "p_enhancement": 3,
             "p_bug": 0,
-            "p_typo": 1, 
+            "p_typo": 1,
             "p_documentation": 3,
             "i_enhancement": 3,
             "i_bug": 0,
             "i_documentation": 3,
         },
-        "test_user11": {
+        "test_user11": {  # doc issue 1개만 있음 → 1점
             "p_enhancement": 0,
             "p_bug": 0,
-            "p_typo": 0, 
+            "p_typo": 0,
             "p_documentation": 0,
             "i_enhancement": 0,
             "i_bug": 0,
@@ -119,7 +118,8 @@ def test_example_calculate_scores():
     assert scores["test_user8"]['total'] == 25, "test_user8 결과값이 일치하지 않습니다."
     assert scores["test_user9"]['total'] == 22, "test_user9 결과값이 일치하지 않습니다."
     assert scores["test_user10"]['total'] == 25, "test_user10 결과값이 일치하지 않습니다."
-    assert scores["test_user11"]['total'] == 0, "test_user11 결과값이 일치하지 않습니다."
+    assert scores["test_user11"]['total'] == 1, "test_user11 결과값이 일치하지 않습니다."
+
 
 def test_generate_table_creates_file():
     output_handler = OutputHandler()
@@ -149,6 +149,7 @@ def test_generate_table_creates_file():
         output_handler.generate_table(scores, save_path=filepath)
         assert os.path.isfile(filepath), "CSV 파일이 생성되지 않았습니다."
 
+
 def test_generate_count_csv_creates_file():
     output_handler = OutputHandler()
     scores = {
@@ -176,13 +177,14 @@ def test_generate_count_csv_creates_file():
         filepath = os.path.join(tmpdir, "test_scores.csv")
         output_handler.generate_count_csv(scores, save_path=filepath)
         assert os.path.isfile(filepath), "count.csv 파일이 생성되지 않았습니다."
-        
+
         # 생성된 파일 내용 확인
         with open(filepath, 'r', encoding='utf-8') as f:
             content = f.read()
             assert "name,feat/bug PR,document PR,typo PR,feat/bug issue,document issue,total" in content
             assert "alice,9,6,1,6,3,25" in content
             assert "bob,9,6,0,6,3,24" in content
+
 
 def test_generate_chart_creates_file():
     output_handler = OutputHandler()
@@ -210,4 +212,4 @@ def test_generate_chart_creates_file():
     with tempfile.TemporaryDirectory() as tmpdir:
         filepath = os.path.join(tmpdir, "test_chart.png")
         output_handler.generate_chart(scores, save_path=filepath)
-        assert os.path.isfile(filepath), "차트 이미지 파일이 생성되지 않았습니다."
+        assert os.path.isfile(filepath),"차트 이미지 파일이 생성되지 않았습니다."

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -110,7 +110,7 @@ def test_example_calculate_scores():
 
     scores = analyzer.calculate_scores()
     assert scores["test_user1"]['total'] == 26, "test_user1 결과값이 일치하지 않습니다."
-    assert scores["test_user2"]['total'] == 16, "test_user2 결과값이 일치하지 않습니다."
+    assert scores["test_user2"]['total'] == 4, "test_user2 결과값이 일치하지 않습니다."
     assert scores["test_user3"]['total'] == 79, "test_user3 결과값이 일치하지 않습니다."
     assert scores["test_user4"]['total'] == 9, "test_user4 결과값이 일치하지 않습니다."
     assert scores["test_user5"]['total'] == 7, "test_user5 결과값이 일치하지 않습니다."


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/729

## Specific Version
69fe5776314fa4d70e39f78a15b6e6b49cf9d14d

## 변경 내용
- PR이 전혀 없는 사용자가 이슈만 작성한 경우, 기존에는 점수가 아예 계산되지 않는 문제가 있었습니다. 이를 해결하기 위해 다음과 같은 보정 로직을 추가했습니다:
- PR이 0개이지만 이슈가 1개 이상 있는 경우 `p_valid=1`로 간주해 1:4 규칙에 따라 이슈 점수를 인정
- 실제 PR 점수는 **모두 0으로 고정**하여 잘못된 점수 반영을 방지
 
 ## ✅ 적용 로직 (요약)
```python
if p_fb == 0 and i_fb + i_d > 0:
    p_valid = 1
    i_valid = min(i_fb + i_d, 4 * p_valid)

    # PR 점수는 0으로 고정
    p_fb_at = 0
    p_d_at = 0
    p_t_at = 0
    i_fb_at = min(i_fb, i_valid)
    i_d_at = i_valid - i_fb_at
