### PR TITLE
[BUG] analyzer.py에서 retry_request() 호출 시 max_retries 매개변수로 인한 TypeError 발생 #739 에 대한 pr입니다.

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -134,7 +134,6 @@ class RepoAnalyzer:
 
             response = retry_request(self.SESSION,
                                     url,
-                                    max_retries=3,
                                     params={
                                         'state': 'all',
                                         'per_page': per_page,

--- a/reposcore/retry_decorator.py
+++ b/reposcore/retry_decorator.py
@@ -33,3 +33,9 @@ def retry(max_retries: int = 3, retry_delay: float = 5):
                     raise
         return wrapper
     return decorator
+
+@retry(max_retries=3, retry_delay=2)
+def retry_request(session, url, params=None, headers=None):
+    response = session.get(url, params=params, headers=headers)
+    response.raise_for_status()
+    return response


### PR DESCRIPTION
## Issue ID 
(https://github.com/oss2025hnu/reposcore-py/issues/739)

## Specific Version
0d431ab788138bbb576288bd1b271d8837ddff7a

## 변경 내용
해당 이슈에서 제기된 retry_request() 호출 시 max_retries 인자를 전달해 TypeError가 발생하는 문제를 수정했습니다.
reposcore/analyzer.py에서 retry_request(..., max_retries=3) 호출 부분을 max_retries 인자 없이 호출하도록 수정했습니다.
reposcore/github_utils.py에 @retry(max_retries=3, retry_delay=2)를 사용해 재시도 로직이 내장된 retry_request() 함수를 정의했습니다.

이후 테스트가 성공적으로 완료되는것을 확인했습니다.
[2025-05-22 07:17:44] oss2025hnu/reposcore-py 분석 결과(CSV, TXT, Chart) 저장 완료: results/oss2025hnu_reposcore-py
저장소 분석 진행: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:07<00:00,  7.64s/it]
[2025-05-22 07:17:44] HTML 보고서 생성 중...
[2025-05-22 07:17:44] HTML 보고서 생성 완료