### PR TITLE
그래프 한글 출력 시 경고 발생 문제 해결

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -286,7 +286,7 @@ class OutputHandler:
         ax.set_yticklabels(ranked_participants)
         ax.set_xlabel('Score')
         ax.set_title(
-            f'Repository Contribution Scores\n(분석 기준 시각: {timestamp})',
+            f'Repository Contribution Scores\n(Generated at {timestamp})',
             fontsize=14,
             loc='center',  # 또는 'left', 'right'
             color='black'
@@ -381,8 +381,8 @@ class OutputHandler:
             )
 
 
-        plt.xlabel("점수")
-        plt.title("사용자별 저장소 기여도 (py/js/cs)")
+        plt.xlabel("Score")
+        plt.title("Repository Contribution Scores (py/js/cs)")
         plt.legend(loc="upper right")
         plt.tight_layout()
         plt.yticks(range(len(ranked_usernames)), ranked_usernames)
@@ -403,9 +403,9 @@ class OutputHandler:
         plt.bar(x - width/2, pr_counts, width, label="PR", color='skyblue')
         plt.bar(x + width/2, issue_counts, width, label="Issue", color='lightgreen')
 
-        plt.xlabel("주차")
-        plt.ylabel("건수")
-        plt.title("주차별 GitHub 활동량 (PR/Issue)")
+        plt.xlabel("Week")
+        plt.ylabel("Count")
+        plt.title("GitHub Activity per Week (PR/Issue)")
         plt.xticks(x, [f"Week {w}" for w in weeks])
         plt.legend()
         plt.tight_layout()


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/700

## Specific Version
7c8649e148dc14ae4fa2d3ac5d78bdd6fc1ad82e

## 변경 내용
그래프에서 한글을 출력 시 경고가 발생하던 문제를 그래프에서 사용하던 한글을 모두 영어로 바꾸어 해결하였습니다.
변경된 한글 -> 영어는 다음과 같습니다.

분석 기준 시각 -> Generated at
점수 -> Score
사용자별 저장소 기여도 -> Repository Contribution Scores
주차 -> Week
건수 -> Count
주차별 GitHub 활동량 -> GitHub Activity per Week