### PR TITLE
[BUG] _generate_score_table_html 함수 버그 #757 에 대한 pr입니다.

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -194,7 +194,9 @@ class OutputHandler:
             '/usr/share/fonts/truetype/baekmuk/baekmuk.ttf'  # 백묵
         ]
 
-        sorted_scores = dict(sorted(scores.items(), key=lambda x: x[1]["rank"]))
+        sorted_items = sorted(scores.items(), key=lambda x: x[1].get("rank", 0))
+        sorted_scores = dict(sorted_items)
+
         participants = list(sorted_scores.keys())
         pr_scores = [sorted_scores[p]['feat/bug PR'] + sorted_scores[p]['document PR'] + sorted_scores[p]['typo PR'] for p in participants]
         issue_scores = [sorted_scores[p]['feat/bug issue'] + sorted_scores[p]['document issue'] for p in participants]
@@ -209,7 +211,7 @@ class OutputHandler:
             else:
                 return f"{rank}th"
 
-        ranked_participants = [f"{user} ({get_ordinal_suffix(int(sorted_scores[user]['rank']))})" for user in participants]
+        ranked_participants = [f"{user} ({get_ordinal_suffix(int(sorted_scores[user].get("rank", 0)))})" for user in participants]
 
         timestamp = self.get_kst_timestamp()
 
@@ -232,7 +234,7 @@ class OutputHandler:
         issue_scores = [score_data["feat/bug issue"] + score_data["document issue"] for _, score_data in sorted_scores]
 
         # 등수 붙이기
-        ranked_participants = [f"{user} ({get_ordinal_suffix(int(scores[user]['rank']))})" for user in participants]
+        ranked_participants = [f"{user} ({get_ordinal_suffix(int(scores[user].get('rank', 0)))})" for user in participants]
 
         for font_path in font_paths:
             if os.path.exists(font_path):

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -133,7 +133,7 @@ class OutputHandler:
         """PrettyTable을 사용해 참여자 점수를 표 형식으로 출력"""
         timestamp = self.get_kst_timestamp()
 
-        sorted_scores = dict(sorted(scores.items(), key=lambda x: x[1]['rank']))
+        sorted_scores = dict(sorted(scores.items(), key=lambda x: x[1].get('rank', 0)))
 
         table = PrettyTable()
         table.field_names = [
@@ -423,7 +423,7 @@ class OutputHandler:
     def _generate_score_table_html(self, scores: dict, repo_name: str) -> str:
         """점수 테이블 HTML 생성"""
         # 총점 기준으로 사용자 정렬
-        sorted_scores = dict(sorted(scores.items(), key=lambda x: x[1]['rank']))
+        sorted_scores = dict(sorted(scores.items(), key=lambda x: x[1].get('rank', 0)))
         
         html = f"""
         <div class="table-responsive">
@@ -445,7 +445,7 @@ class OutputHandler:
             grade = self._calculate_grade(total_score)
             html += f"""
                     <tr>
-                        <td>{score_data['rank']}</td>
+                        <td>{score_data.get('rank', '-')}</td>
                         <td>{user}</td>
                         <td>{total_score:.1f}</td>
                         <td>{grade}</td>


### PR DESCRIPTION
## Issue ID 
(https://github.com/oss2025hnu/reposcore-py/issues/757)

## Specific Version
7ec9a798b1c00b6a04f35190ed8ac9ce07b02326

## 변경 내용
output handler. generate_chart() 내부에서 rank필드가 누락된 입력에서도 제대로 작동하도록 방어로직을 추가했습니다.


**테스트 시행후 결과가 제대로 생성되는것을 확인했습니다**

[2025-05-24 14:32:17] 저장소 분석 시작: oss2025hnu/reposcore-py, oss2025hnu/reposcore-js, oss2025hnu/reposcore-cs
저장소 분석 진행:   0%|                                                                                                                                                                                                                              | 0/3 [00:00<?, ?it/s][2025-05-24 14:32:24] oss2025hnu/reposcore-py 분석 결과(CSV, TXT, Chart) 저장 완료: results/oss2025hnu_reposcore-py
저장소 분석 진행:  33%|███████████████████████████████████████████████████████████████████████▎                                                                                                                                              | 1/3 [00:07<00:14,  7.35s/it][2025-05-24 14:32:29] oss2025hnu/reposcore-js 분석 결과(CSV, TXT, Chart) 저장 완료: results/oss2025hnu_reposcore-js
저장소 분석 진행:  67%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                                       | 2/3 [00:12<00:06,  6.04s/it][2025-05-24 14:32:32] oss2025hnu/reposcore-cs 분석 결과(CSV, TXT, Chart) 저장 완료: results/oss2025hnu_reposcore-cs
저장소 분석 진행: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:15<00:00,  5.12s/it]
[2025-05-24 14:32:32] 
=== 전체 저장소 통합 분석 ===
[2025-05-24 14:32:32] ℹ️ [통합 분석] 여러 저장소의 통합 분석을 수행합니다.
[2025-05-24 14:32:34] [통합 저장소] 분석 결과(CSV, TXT, Chart) 저장 완료: results/overall
[2025-05-24 14:32:36] [📊 overall_repository] 분석 결과(CSV, TXT, Chart) 저장 완료: results/overall_repository
[2025-05-24 14:32:36] [📊 overall_repository] 통합 저장소 기준 사용자별 기여도는 'results/overall_repository' 폴더 내 결과 파일에서 확인할 수 있습니다.
[2025-05-24 14:32:36] HTML 보고서 생성 중...
[2025-05-24 14:32:36] HTML 보고서 생성 완료

**make test 에서 key Error가 생기지 않음을 확인했습니다.**

== test session starts ===========================================================================================================================
platform linux -- Python 3.12.1, pytest-8.3.5, pluggy-1.6.0
rootdir: /workspaces/reposcore-py-kjs
collected 8 items                                                                                                                                                                                                                                                         

tests/test_analyzer.py ....                                                                                                                                                                                                                                         [ 50%]
tests/test_decorators.py ..                                                                                                                                                                                                                                         [ 75%]
tests/test_main.py ..                                                                                                                                                                                                                                               [100%]

============================================================================================================================ 8 passed in 3.07s ====