### PR TITLE
[DOC] README.md 생성 명령을 ci.yaml에 넣어서 깃헙 액션 자동화 에 대한 pr입니다.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
           git add README.md
           git diff --cached --quiet || (
             git commit -m "docs: 자동 생성된 README 갱신"  # ← 변경 있을 경우에만 커밋
-            git push https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}  # ← 토큰 푸시
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}  # ← 토큰 푸시
           )
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: 리포지토리 체크아웃
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Python 환경 설정
         uses: actions/setup-python@v5
@@ -40,3 +42,19 @@ jobs:
         with:
           name: test-results
           path: test-results.xml
+
+      - name: README.md 자동 생성 
+        run: |
+          python generate_readme.py  # ← README 생성 스크립트 실행
+
+      - name: 변경 사항 커밋 및 푸시 
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add README.md
+          git diff --cached --quiet || (
+            git commit -m "docs: 자동 생성된 README 갱신"  # ← 변경 있을 경우에만 커밋
+            git push https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}  # ← 토큰 푸시
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }} 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,10 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           git add README.md
-          git diff --cached --quiet || (
+          git diff --cached --quiet && echo "README 변경 없음 - 커밋 생략됨" || (
+            echo "README 변경 감지 = 커밋 및 푸시 실행"
             git commit -m "docs: 자동 생성된 README 갱신"  # ← 변경 있을 경우에만 커밋
-            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}  # ← 토큰 푸시
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}
           )
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: README.md 자동 생성 
         run: |
-          python generate_readme.py  # ← README 생성 스크립트 실행
+          python scripts/generate_readme.py  # ← README 생성 스크립트 실행
 
       - name: 변경 사항 커밋 및 푸시 
         run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make requirements
 **⚠️ 반드시 저장소 최상위 디렉토리에서 실행해야 합니다. (python -m reposcore 명령은 상대 경로 기준으로 동작합니다.)**
 
 ```
-usage: python -m reposcore [-h] [-v] [owner/repo ...] [--output dir_name] [--format {table, text, chart, all}] [--check-limit] [--user-info path]
+usage: python -m reposcore [-h] [-v] [owner/repo ...] [--output dir_name] [--format {table, text, chart, html, all}] [--check-limit] [--user-info path]
 
 오픈 소스 수업용 레포지토리의 기여도를 분석하는 CLI 도구
 
@@ -34,7 +34,7 @@ options:
   -h, --help            도움말 표시 후 종료
   -v, --verbose         자세한 로그를 출력합니다.
   --output dir_name     분석 결과를 저장할 출력 디렉토리 (기본값: 'results')
-  --format {table, text, chart, all} [{table, text, chart, all} ...]
+  --format {table, text, chart, html, all} [{table, text, chart, html, all} ...]
                         결과 출력 형식 선택 (복수 선택 가능, 예: --format table chart)
                         (기본값:'all')
   --grade               차트에 등급 표시
@@ -98,7 +98,7 @@ python -m reposcore <소유자/저장소> --semester-start YYYY-MM-DD --weekly-c
 
 ### py저장소 메인 모듈의 의미와 역할
 해당 프로젝트의 핵심 기능이 구현되어 있는 중심적인 파일입니다.
-일반적으로 __main__.py 이나 저장소 이름과 같은 파일로 구성되며, 프로그램을 실행할때 전체 흐름을 제어하는 중심 모듈 역할을 합니다.
+일반적으로 `__main__.py` 이나 저장소 이름과 같은 파일로 구성되며, 프로그램을 실행할때 전체 흐름을 제어하는 중심 모듈 역할을 합니다.
 이 모듈은 다음 역할을 수행합니다:
  - 애플리케이션 진입점 제공
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/586

## Specific Version

d33d65f74fe50fd777d0153143103ca7028e3eb7

## 변경 내용

**ci.yaml에 다음과 같은 작업을 추가했습니다.**
1. scripts/generate_readme.py을 실행하여 README.md를 자동 생성
2. 변경사항이 있을 경우에만 커밋/푸시
3. 변경 사항이 없을 경우에도 로그를 출력하여 해당 기능이 정상적으로 작동하고 있음을 확인

**과거 반려됐던 pr과의 차이점 및 피드백 준수 여부**
과거 반려된 pr에서는 다음 두가지의 문제가 있었던 것으로 보입니다.
1. makefile 실행위치 오류 (scripts 디렉토리 에서 make명령 실행)
2. 테스트, 의존성 설치등 이미 문서화, 자동화 된 불필요한 추가 작업

준수 여부
1. python scripts/generate_readme.py 로 직접 실행하여 해당 문제를 해결하였습니다.
2.  README 자동 생성에 필요한 최소한의 작업만을 추가하였습니다. 


**테스트 및 오류 여부 확인 결과**
실제 워크플로우를 여러 번 실행하여 수정한 코드가 정상 작동하는지 확인했습니다.
운이 좋게도 readme가 이미 이전 참여자에 의해 수정되어있던 상황이라 임의로 readme를 변경하지 않고도 해당 기능을 테스트 할 수 있었습니다.
다음은 로그 기록입니다.

Run python scripts/generate_readme.py  # ← README 생성 스크립트 실행
✅ README.md generated from template_README.md
0s
Run git config --global user.name "github-actions"
[586 7d4adac] docs: 자동 생성된 README 갱신
 [1](https://github.com/kjason0102/reposcore-py-kjs/actions/runs/15245825565/job/42872400146#step:9:1) file changed, 3 insertions(+), 3 deletions(-)
To https://github.com/kjason0102/reposcore-py-kjs
   63db340..7d4adac  HEAD -> 586

- 변경사항이 없을 경우
Run git config --global user.name "github-actions"
README 변경 없음 - 커밋 생략됨

-docs: 자동 생성된 readme갱신 : 커밋이 정상적으로 push되는것을 확인했습니다.
