### PR TITLE
html overall repository 정렬 및 순위표시

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -443,6 +443,22 @@ def main() -> None:
         for username in user_scores:
             user_scores[username]["total"] = sum(user_scores[username].values())
 
+        # 정렬
+        user_scores = defaultdict(dict, sorted(user_scores.items(), key=lambda x: x[1]['total'], reverse=True))
+        # rank 추가
+        current_rank = 1
+        prev_score = None
+
+        for i, (username, scores) in enumerate(user_scores.items()):
+            current_score = scores['total']
+            
+            # 동점자 처리
+            if prev_score is not None and current_score != prev_score:
+                current_rank = i + 1
+            
+            user_scores[username]['rank'] = current_rank
+            prev_score = current_score
+
         # 통합 결과 저장
         overall_output_dir = os.path.join(args.output, "overall")
         os.makedirs(overall_output_dir, exist_ok=True)


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/764

## Specific Version
471c7821af912943cd6a148b08d3e05398418d90

## 변경 내용
기존 html 에서 생성되던 overall repository의 테이블이 정렬이 되지 않고, 순위가 표시되지 않던 문제를 해결하였습니다.
`__main__.py`의 overall repository의 딕셔너리에 해당하던 user_scores를 정렬하는 코드와 rank값을 삽입하는 코드를 추가하였습니다.
수정이후 테이블이 올바르게 출력되는 모습을 보입니다.

![스크린샷 2025-05-27 135301](https://github.com/user-attachments/assets/78804c6d-377f-452a-bf3f-ae7fa5ca3351)
