### PR TITLE
[BUG] --format html 옵션의 cvs 파일 오류 해결

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -347,7 +347,7 @@ def main() -> None:
             results_saved = []
 
             # 1) CSV 테이블 저장
-            if FORMAT_TABLE in formats:
+            if FORMAT_TABLE in formats or FORMAT_HTML in formats:
                 table_path = os.path.join(repo_output_dir, "score.csv")
                 output_handler.generate_table(repo_scores, save_path=table_path)
                 output_handler.generate_count_csv(repo_scores, save_path=table_path)

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -493,7 +493,8 @@ class OutputHandler:
             rel_weekly_chart_path = os.path.join(repo_name, os.path.basename(weekly_chart_path)) if weekly_chart_path else ''
 
             # CSV 다운로드 버튼 추가
-            csv_path = f"{repo_name}/score.csv"
+            csv_filename = "overall_scores.csv" if repo_name == "overall_repository" else "score.csv"
+            csv_path = f"{repo_name}/{csv_filename}"
             download_button = f"""
             <div class="text-end mt-2 mb-3">
                 <a href="{csv_path}" download class="btn btn-outline-primary">Download Score CSV</a>


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/780

## Specific Version
5d7e991f47a2fd66f03382b8c011f64ec86889a9

## 변경 내용
HTML 보고서에서 CSV 다운로드 버튼은 있지만, --format html 옵션만 사용할 경우 score.csv가 생성되지 않아 다운로드가 실패하는 문제를 해결합니다.

main.py에서 score.csv 생성 조건을 다음과 같이 수정:
if FORMAT_TABLE in formats or FORMAT_HTML in formats:
HTML 리포트가 포함될 때도 항상 score.csv 파일이 생성되도록 하여 HTML 내 Download CSV 버튼이 정상 동작하도록 보장합니다.

overall_scores.csv라는 실제 파일명과 링크 경로 불일치로 인해 output_handler.py에서 링크 생성 부분을 파일명 분기 처리했습니다.