### PR TITLE
HTML의 overall 탭을 첫 번째에 표시

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -478,9 +478,12 @@ class OutputHandler:
 
         # 중복 추가 방지용 집합
         added_tabs = set()
+                
+        # overall이 존재할 경우 맨 앞의 순서로 변경
+        sorted_items = sorted(all_repo_data.items(), key=lambda x: (x[0] != 'overall', x[0]))
 
         # 각 저장소별로 탭과 콘텐츠 생성
-        for i, (repo_name, repo_data) in enumerate(all_repo_data.items()):
+        for i, (repo_name, repo_data) in enumerate(sorted_items):
             if repo_name in added_tabs:
                 continue  # 중복 방지
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/784

## Specific Version
44fa8428006e79a56630e320fd570d29e1cc225d

## 변경 내용
`output_handler.py`의  `generate_html_report` 함수에서 html의 각 탭을 생성하기 위한 for문에서 사용되던 `all_repo_data`의 엔트리 
순서를  `overall` 키를 맨 앞으로 위치하였고, 그 외의 순서는 기존의 순서를 유지하였습니다.

![스크린샷 2025-05-28 232243](https://github.com/user-attachments/assets/5cb7323d-4f4e-4c50-84a9-aac553f6dc38)
 
