### PR TITLE
HTML의 생성 시간 수정

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -561,7 +561,7 @@ class OutputHandler:
             added_tabs.add(repo_name)
 
         # HTML 템플릿
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        timestamp = self.get_kst_timestamp()
 
         # HTML 생성
         html = f"""


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/788

## Specific Version
c6b58901b1b0ca7df3f62b8fec3c4086632a2e41

## 변경 내용
변경전
timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
변경 후
timestamp = self.get_kst_timestamp()
HTML 보고서 상단의 생성 일시가 차트 생성 시간과 일치하게 되고, 한국 시간(KST) 기준으로 일관되게 표현되게 했습니다.