### PR TITLE
터미널 상의 시간 로그 오류 수정

### DIFF
--- a/reposcore/common_utils.py
+++ b/reposcore/common_utils.py
@@ -2,6 +2,7 @@ import sys
 import logging
 
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 is_verbose = False
 
@@ -29,5 +30,6 @@ def get_ordinal_suffix(rank):
 # -v or --vebose 옵션에 따라 로그를 다르게 출력하는 함수
 def log(message: str, force: bool = False):
     if is_verbose or force:
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        kst = ZoneInfo("Asia/Seoul")
+        timestamp = datetime.now(tz=kst).strftime("%Y-%m-%d %H:%M:%S")
         print(f"[{timestamp}] {message}")


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/794

## Specific Version
c6b58901b1b0ca7df3f62b8fec3c4086632a2e41

## 변경 내용
common_utils.py의 log() 함수에서 zoneinfo 모듈을 통해 Asia/Seoul 시간대를 적용하도록 수정했습니다.
