### PR TITLE
[BUG] 하위권 user 의 점수가 js와 py 점수 차이에 대한 PR

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -338,7 +338,7 @@ class RepoAnalyzer:
             p_valid, i_valid = self._calculate_valid_counts(p_fb, p_d, p_t, i_fb, i_d)
 
             # ✅ PR 0개인데 이슈만 있는 경우 1:4 규칙 보정
-            if p_fb == 0 and i_fb + i_d > 0:
+            if p_fb == 0 and p_d == 0 and p_t == 0 and (i_fb + i_d) > 0:
                 # PR은 없지만, 이슈를 위해 PR 1개 있다고 간주 (계산용)
                 p_valid = 1
                 i_valid = min(i_fb + i_d, 4 * p_valid)


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/795 에 대한 PR입니다.

## Specific Version
57d655e63166bc6be1cb9f303777b73994f59d7b

## 변경 내용
기존 오류가 있던 RepoAnalyzer.calculate_scores() 계산식을 수정하여
문서 PR과 문서 이슈가 모두 있는 경우, 예상 점수(3점)와 다르게 1점만 계산되는 문제를 수정하였습니다.