### PR TITLE
[BUG] overall_repository 동점자 등수 처리 오류 에 대한 pr입니다.

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -539,8 +539,15 @@ def main() -> None:
         df = df.astype(int)
         df.reset_index(inplace=True)
         df = df[["name"] + existing_columns]
-        df = df.sort_values(by="total", ascending=False)
+        df['rank'] = df['total'].rank(method='min', ascending=False).astype(int)
+        for _, row in df.iterrows():
+            username = row['name']
+            user_scores[username]['rank'] = int(row['rank'])
+        df = df.sort_values(by='rank')
+        cols = ['rank'] + [col for col in df.columns if col != 'rank']
+        df = df[cols]
         df.to_csv(output_path, encoding="utf-8", index=False)
+        return user_scores
     
     if len(final_repositories) > 1:
         # 저장 경로 지정하고 생성
@@ -549,6 +556,7 @@ def main() -> None:
         results_saved = []
 
         overall_csv_path = os.path.join(overall_repo_dir, "overall_scores.csv")
+        user_scores = generate_overall_repository_csv(all_repo_scores, overall_csv_path)
         generate_overall_repository_csv(all_repo_scores, overall_csv_path)
         if args.verbose:
             log(f"[📊 overall_repository] 저장소별 사용자 점수 CSV 저장 완료: {overall_csv_path}", force=True)
@@ -561,18 +569,10 @@ def main() -> None:
         table = PrettyTable()
         table.field_names = ["Rank", "Name"] + [repo.replace("/", "_") for repo in final_repositories] + ["Total"]
 
-        user_scores = defaultdict(dict)
-        for repo_name, repo_scores in all_repo_scores.items():
-            for username, score_dict in repo_scores.items():
-                user_scores[username][repo_name] = score_dict["total"]
-
-        for username in user_scores:
-            user_scores[username]["total"] = sum(user_scores[username].values())
-
         sorted_users = sorted(user_scores.items(), key=lambda x: x[1]["total"], reverse=True)
 
-        for rank, (username, score_dict) in enumerate(sorted_users, start=1):
-            row = [rank, username]
+        for username, score_dict in sorted_users:
+            row = [score_dict['rank'], username]
             for repo in final_repositories:
                 repo_key = repo.replace("/", "_")
                 row.append(score_dict.get(repo_key, 0))

--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -557,7 +557,6 @@ def main() -> None:
 
         overall_csv_path = os.path.join(overall_repo_dir, "overall_scores.csv")
         user_scores = generate_overall_repository_csv(all_repo_scores, overall_csv_path)
-        generate_overall_repository_csv(all_repo_scores, overall_csv_path)
         if args.verbose:
             log(f"[📊 overall_repository] 저장소별 사용자 점수 CSV 저장 완료: {overall_csv_path}", force=True)
         results_saved.append("CSV")

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -335,7 +335,7 @@ class OutputHandler:
         repo_keys = sorted(repo_keys)  # 보기 좋게 정렬해도 OK
 
         # 총점 기준 내림차순 정렬
-        sorted_users = sorted(scores.items(), key=lambda x: x[1].get("total", 0), reverse=True)
+        sorted_users = sorted(scores.items(), key=lambda x: x[1].get("rank", float('inf')))
         usernames = [user for user, _ in sorted_users]
 
         # 서수 붙이기 (1st, 2nd, 3rd ...)
@@ -349,7 +349,7 @@ class OutputHandler:
             else:
                 return f"{rank}th"
 
-        ranked_usernames = [f"{user} ({get_ordinal_suffix(i+1)})" for i, user in enumerate(usernames)]
+        ranked_usernames = [f"{user} ({get_ordinal_suffix(score.get('rank', 0))})" for user, score in sorted_users]
 
         usernames = usernames[::-1]
         ranked_usernames = ranked_usernames[::-1]
@@ -445,6 +445,7 @@ class OutputHandler:
                 <tbody>
         """.format(repo_name=repo_name)
         
+        sorted_scores = dict(sorted(scores.items(), key=lambda x: x[1].get('rank', 0)))
         for user, score_data in sorted_scores.items():
             total_score = score_data.get('total', 0)
             grade = self._calculate_grade(total_score)

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -331,7 +331,7 @@ class OutputHandler:
         # ✅ 모든 사용자 기준으로 저장소 키 수집
         repo_keys = set()
         for user_data in scores.values():
-            repo_keys.update([k for k in user_data.keys() if k not in ["total", "grade"]])
+            repo_keys.update([k for k in user_data.keys() if k not in ["total", "grade", "rank"]])
         repo_keys = sorted(repo_keys)  # 보기 좋게 정렬해도 OK
 
         # 총점 기준 내림차순 정렬


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/785

## Specific Version
57d655e63166bc6be1cb9f303777b73994f59d7b

## 변경 내용
- overall 통합 점수 결과에서 동점자 동일 순위 처리(1, 2, 2, 4...) 적용하도록 변경
- overall_scores.csv, overall_scores.txt, overall_chart.png, HTML 보고서 등 모든 출력에 반영됨

|  7   |   jungsuryeon    |            47           |            62           |            2            |  111  |
|  8   |   Jae-Hyuk-Lee   |            33           |            77           |            0            |  110  |
|  9   |    bym010312     |            72           |            36           |            0            |  108  |
|  9   |    jaewon786     |            68           |            40           |            0            |  108  |
|  11  |    kjason0102    |            70           |            23           |            0            |   93  |
