### PR TITLE
[BUG] 하위권 user 의 점수가 js와 py 점수 차이에 대한 PR 

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -338,7 +338,7 @@ class RepoAnalyzer:
             p_valid, i_valid = self._calculate_valid_counts(p_fb, p_d, p_t, i_fb, i_d)
 
             # ✅ PR 0개인데 이슈만 있는 경우 1:4 규칙 보정
-            if p_fb == 0 and i_fb + i_d > 0:
+            if p_fb == 0 and p_d == 0 and p_t == 0 and (i_fb + i_d) > 0:
                 # PR은 없지만, 이슈를 위해 PR 1개 있다고 간주 (계산용)
                 p_valid = 1
                 i_valid = min(i_fb + i_d, 4 * p_valid)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -15,7 +15,7 @@ def test_example_calculate_scores():
             "i_bug": 2,
             "i_documentation": 2,
         },
-        "test_user2": {  # 5 = 1 typo + 4 doc issues (1:4 보정)
+        "test_user2": {  # 16 = 2*3 + 1*10 (문서 PR 3개 + 문서 이슈 10개)
             "p_enhancement": 0,
             "p_bug": 0,
             "p_typo": 1,
@@ -109,7 +109,7 @@ def test_example_calculate_scores():
 
     scores = analyzer.calculate_scores()
     assert scores["test_user1"]['total'] == 26, "test_user1 결과값이 일치하지 않습니다."
-    assert scores["test_user2"]['total'] == 5,"test_user2 결과값이 일치하지 않습니다."
+    assert scores["test_user2"]['total'] == 16,"test_user2 결과값이 일치하지 않습니다."
     assert scores["test_user3"]['total'] == 79, "test_user3 결과값이 일치하지 않습니다."
     assert scores["test_user4"]['total'] == 9, "test_user4 결과값이 일치하지 않습니다."
     assert scores["test_user5"]['total'] == 7, "test_user5 결과값이 일치하지 않습니다."


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/795 에 대한 PR입니다.

## Specific Version
57d655e

## 변경 내용
기존 오류가 있던 RepoAnalyzer.calculate_scores() 계산식을 수정하여
문서 PR과 문서 이슈가 모두 있는 경우, 예상 점수(3점)와 다르게 1점만 계산되는 문제를 수정하였습니다.
