### PR TITLE
텍스트 파일 결과물의 실수형 포맷팅을 정수형으로 형변환

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -145,15 +145,15 @@ class OutputHandler:
         for rank, (name, score) in enumerate(scores.items(), start=1):
             grade = self._calculate_grade(score["total"])
             table.add_row([
-                f"{int(score['rank'])}",
+                int(score['rank']),
                 name,
-                f"{score['total']:5.1f}",
+                int(score['total']),
                 grade,
-                f"{score['feat/bug PR']:5.1f}",
-                f"{score['document PR']:5.1f}",
-                f"{score['typo PR']:5.1f}",
-                f"{score['feat/bug issue']:5.1f}",
-                f"{score['document issue']:5.1f}",
+                int(score['feat/bug PR']),
+                int(score['document PR']),
+                int(score['typo PR']),
+                int(score['feat/bug issue']),
+                int(score['document issue']),
             ])
         
         # 평균, 최고점, 최저점


### PR DESCRIPTION
## Issue ID 
테이블의 실수 표기 방식 변경 https://github.com/oss2025hnu/reposcore-py/issues/791 에 대한 PR입니다.

## Specific Version
5b627b379cfc71abb2bf122a0af8750387cc640a

## 변경 내용
txt 파일을 생성하는 코드를 아래와 같이 수정
```bash
f"{score['total']:5.1f}" -> int(score['total'])
```
보이는 것 뿐 아니라 값을 완전히 정수형으로 바꾸기 위해 형변환을 사용
