### PR TITLE
실행 동작 확인을 위한 Dry-Run 모드 (--dry-run) 옵션 추가

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -51,10 +51,11 @@ class RepoAnalyzer:
     # 사용자 제외 목록
     EXCLUDED_USERS = {"kyahnu", "kyagrd"}
 
-    def __init__(self, repo_path: str, theme: str = 'default'):  # token 파라미터 제거
+    def __init__(self, repo_path: str, theme: str = 'default', dry_run: bool = False):  # token 파라미터 제거 
         # 테스트용 저장소나 통합 분석용 저장소 식별
         self._is_test_repo = repo_path == "dummy/repo"
         self._is_multiple_repos = repo_path == "multiple_repos"
+        self.dry_run = dry_run
         
         # 테스트용이나 통합 분석용이 아닌 경우에만 실제 저장소 존재 여부 확인
         if not self._is_test_repo and not self._is_multiple_repos:
@@ -130,6 +131,9 @@ class RepoAnalyzer:
         PR의 경우, 실제로 병합된 경우만 점수에 반영.
         이슈는 open / reopened / completed 상태만 점수에 반영합니다.
         """
+        if self.dry_run:
+            log(f"[DRY-RUN] '{self.repo_path}'에 대해 PR/이슈 수집을 생략합니다.", force=True)
+            return
         # 테스트용 저장소나 통합 분석용인 경우 API 호출을 건너뜁니다
         if self._is_test_repo:
             logging.info(f"ℹ️ [TEST MODE] '{self.repo_path}'는 테스트용 저장소입니다. 실제 GitHub API 호출을 수행하지 않습니다.")

--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -45,9 +45,10 @@ class OutputHandler:
         0: 'F'
     }
 
-    def __init__(self, theme: str = 'default'):
+    def __init__(self, theme: str = 'default', dry_run: bool = False):
         self.theme_manager = ThemeManager()  # 테마 매니저 초기화
         self.set_theme(theme)                # 테마 설정
+        self.dry_run = dry_run              
 
     def set_theme(self, theme_name: str) -> None:
         if theme_name in self.theme_manager.themes:
@@ -86,6 +87,9 @@ class OutputHandler:
 
     def generate_table(self, scores: dict[str, dict[str, float]], save_path) -> None:
         """결과를 테이블 형태로 출력"""
+        if self.dry_run:
+            print(f"[DRY-RUN] 테이블 저장 생략 (예상 경로: {save_path})")
+            return
         timestamp = self.get_kst_timestamp()
         table = PrettyTable()
         table.field_names = ["참여자", "총점", "등급", "PR(기능/버그)", "PR(문서)", "PR(오타)", "이슈(기능/버그)", "이슈(문서)"]


### PR DESCRIPTION
## Issue ID 
#691 

## Specific Version
0fbea9b731e333d734cc9e2b3bf69d4bc1e745a1

## 변경 내용
- `--dry-run` 옵션을 추가하여 실제 작업 없이 동작 시뮬레이션 정보만 출력하도록 지원
  - 캐시 사용 여부, API 호출 여부, 저장 파일 경로를 출력
  - 실제 GitHub API 호출 및 결과 파일 저장은 생략
![image](https://github.com/user-attachments/assets/757bb76f-67e6-4285-9aa3-008ea607af19)