### PR TITLE
분석 시 사용된 CLI 옵션 로그로 저장

### DIFF
--- a/reposcore/__main__.py
+++ b/reposcore/__main__.py
@@ -187,10 +187,16 @@ def merge_participants(
                 overall[user][key] = overall[user].get(key, 0) + value
     return overall
 
+def save_cli_args(args, output_dir="results"):
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "settings.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(vars(args), f, indent=2, ensure_ascii=False)
 
 def main() -> None:
     """Main execution function"""
     args = parse_arguments()
+    save_cli_args(args, args.output)
 
     # repository가 없으면 에러
     if not args.repository:


### PR DESCRIPTION
## Issue ID 
#776 

## Specific Version
f6007c94046c0235743c55c49e6f56e6593d81e3

## 변경 내용
- 사용자가 실행한 CLI 옵션들을 results/settings.json 파일로 저장하는 기능을 추가했습니다.
- argparse로 파싱된 args 객체를 json 형태로 직렬화하여 분석 결과 디렉토리에 함께 저장됩니다.
- 실행 조건 재현이 가능하도록 CLI 실행 이력을 남기는 기능입니다.

## 예시
```bash
python -m reposcore oss2025hnu/reposcore-py --format chart --use-cache --dry-run
```
```json
{
  "repository": [
    "oss2025hnu/reposcore-py"
  ],
  "verbose": false,
  "output": "results",
  "format": [
    "table"
  ],
  "grade": false,
  "use_cache": true,
  "token": null,
  "check_limit": false,
  "user_info": null,
  "user": null,
  "theme": "default",
  "weekly_chart": false,
  "semester_start": null,
  "min_contributions": 1,
  "dry_run": true
}