### PR TITLE
bug: --user-info 에러 해결

### DIFF
--- a/reposcore/analyzer.py
+++ b/reposcore/analyzer.py
@@ -401,10 +401,6 @@ class RepoAnalyzer:
         if min_contributions > 0:
             scores = {user: s for user, s in scores.items() if s["total"] >= min_contributions}
 
-        # 사용자 정보 매핑 (제공된 경우)
-        if user_info:
-            scores = {user_info[k]: scores.pop(k) for k in list(scores.keys()) if user_info.get(k) and scores.get(k)}
-
         return self._finalize_scores(scores, total_score_sum, user_info)
     
     def set_semester_start_date(self, date: datetime.date) -> None:


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-py/issues/820

## Specific Version
314612ec32686d1e8837cd11a9b7e5dfb2fb21d6

## 변경 내용
calculate_scores 함수와 _finalize_scores 함수에서 user_info 매핑이 두 번 일어나면서 두 번째 매핑 시점에 scores가 비어 오류가 
발생했기 때문에 calculate_scores 함수의 user_info 매핑 부분을 제거 했습니다.
