### PR TITLE
[CLI] --preset 옵션 추가로 입력 로그인

### DIFF
--- a/reposcore/output_handler.py
+++ b/reposcore/output_handler.py
@@ -312,6 +312,14 @@ class OutputHandler:
         ax.set_yticks(range(len(ranked_participants)))
         ax.set_yticklabels(ranked_participants)
         ax.set_xlabel('Score')
+    if self.theme == "dark":
+        ax.tick_params(colors='white')
+        for label in ax.get_xticklabels() + ax.get_yticklabels():
+            label.set_color('white')
+        title_color = 'white'
+    else:
+        title_color = 'title_color'
+
         ax.set_title(
             f'Repository Contribution Scores\n(Generated at {timestamp})',
             fontsize=14,

--- a/template_README.md
+++ b/template_README.md
@@ -14,6 +14,11 @@ A CLI for scoring student participation in an open-source class repo, implemente
 make venv
 make requirements
 ```
+예시:
+
+```bash
+python -m reposcore <repo> --format chart --theme dark
+python -m reposcore <repo> --format chart --theme default
 
 ## Usage
 아래는 `python -m reposcore -h` 또는 `python -m reposcore --help` 실행 결과를 붙여넣은 것이므로


### PR DESCRIPTION
## 작업 개요
CLI 사용 시 자주 쓰는 옵션 조합을 한 번에 지정할 수 있도록  
`--preset` 옵션(현재는 `semester` 프리셋)을 추가했습니다.

## 변경 내용
- argparse에 `--preset` 인자 추가
- `--preset semester` 선택 시
  - `--format all`
  - `--semester-start 2024-03-04`
  - `--weekly-chart`
  가 자동으로 설정되도록 처리

## 개선 효과
- 매번 복잡한 옵션을 입력하지 않아도 되어 사용성이 크게 향상됩니다.
- 향후 프리셋 유형을 추가(예: midterm, final)할 수 있는 확장 포인트 확보.

Closes #448
